### PR TITLE
Include user organization id in membership response

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -18,6 +18,7 @@ class OrganizationMembershipResponse(SQLModel):
     name: str
     team_number: Optional[int] = None
     role: UserRole
+    user_organization_id: int
 
 
 @router.get("/user/info")
@@ -41,19 +42,20 @@ async def get_my_organizations(
         user_id = UUID(user_id)
 
     statement = (
-        select(Organization, UserOrganization.role)
+        select(Organization, UserOrganization)
         .join(UserOrganization, UserOrganization.organization_id == Organization.id)
         .where(UserOrganization.user_id == user_id)
     )
     result = await session.exec(statement)
     memberships = []
-    for organization, role in result.all():
+    for organization, membership in result.all():
         memberships.append(
             OrganizationMembershipResponse(
                 id=organization.id,
                 name=organization.name,
                 team_number=organization.team_number,
-                role=role,
+                role=membership.role,
+                user_organization_id=membership.id,
             )
         )
     return memberships


### PR DESCRIPTION
## Summary
- add the user organization entry identifier to the organization membership response model
- update the membership query to return the user organization row so its id and role can be exposed

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68d4a96b4fd48326b5d200d325c5ed2e