### PR TITLE
Move organizations listing to user router

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -66,15 +66,6 @@ async def create_organization(
         team_number=newOrg.team_number
     )
 
-@router.get("/organizations")
-async def get_all_organizations(session: AsyncSession = Depends(get_session)) -> List[OrganizationResponse]:
-    statement = select(Organization)
-    result = await session.execute(statement)
-    organizations = result.scalars().all()  # <-- returns list of Organizations
-    if not organizations:
-        raise HTTPException(status_code=404, detail="No organizations found for this event")
-    return [OrganizationResponse(id=o.id, name=o.name, team_number=o.team_number) for o in organizations]
-
 @router.post("/teams/update")
 async def update_team_list(session: AsyncSession = Depends(get_session)) -> dict:
     pagenum = 0


### PR DESCRIPTION
## Summary
- move the organizations listing endpoint from the admin router to the user router and expose it at `/organizations`
- add an Organization response model within the user routes and tag the endpoint as Organization

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68d4ac2f21308326a20237130391fb92