### PR TITLE
Add match schedule export endpoint

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -1,4 +1,9 @@
-from fastapi import APIRouter, Depends
+import csv
+import io
+import json
+from html import escape
+
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
 from db.database import get_session
@@ -31,6 +36,57 @@ async def get_match_schedule(
 ) -> List[MatchScheduleResponse]:
     event_code = await get_active_event_key_for_user(session, user)
     return await get_match_schedule_or_404(session, event_code)
+
+
+@router.post("/matches/export")
+async def export_match_schedule(
+    request: MatchExportRequest,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> Response:
+    event_code = await get_active_event_key_for_user(session, user)
+    matches = await get_match_schedule_or_404(session, event_code)
+    match_dicts = [match.dict() for match in matches]
+
+    if not match_dicts:
+        raise HTTPException(status_code=404, detail="No matches available to export")
+
+    if request.file_type == MatchExportType.CSV:
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=match_dicts[0].keys())
+        writer.writeheader()
+        writer.writerows(match_dicts)
+        content = buffer.getvalue()
+        media_type = "text/csv"
+        extension = "csv"
+    elif request.file_type == MatchExportType.JSON:
+        content = json.dumps(match_dicts, indent=2)
+        media_type = "application/json"
+        extension = "json"
+    elif request.file_type == MatchExportType.XLS:
+        headers = match_dicts[0].keys()
+        header_row = "".join(f"<th>{escape(str(column))}</th>" for column in headers)
+        body_rows = "".join(
+            "<tr>" + "".join(
+                f"<td>{escape(str(row[column]))}</td>" for column in headers
+            ) + "</tr>"
+            for row in match_dicts
+        )
+        content = (
+            "<html><head><meta charset='utf-8'></head><body>"
+            f"<table><thead><tr>{header_row}</tr></thead><tbody>{body_rows}</tbody></table>"
+            "</body></html>"
+        )
+        media_type = "application/vnd.ms-excel"
+        extension = "xls"
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="{event_code}_matches.{extension}"'
+    }
+
+    return Response(content=content, media_type=media_type, headers=headers)
 
 
 @router.get("/organizations")

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from fastapi import HTTPException
 from sqlmodel import select, delete, SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -25,6 +27,16 @@ class MatchScheduleResponse(SQLModel):
     blue1_id: int
     blue2_id: int
     blue3_id: int
+
+
+class MatchExportType(str, Enum):
+    CSV = "csv"
+    JSON = "json"
+    XLS = "xls"
+
+
+class MatchExportRequest(SQLModel):
+    file_type: MatchExportType
 
 class TeamRecordResponse(SQLModel):
     team_number: int

--- a/tests/test_match_export.py
+++ b/tests/test_match_export.py
@@ -1,0 +1,179 @@
+import asyncio
+import os
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+from app.main import app
+from app.auth.dependencies import get_current_user
+from app.models import (
+    FRCEvent,
+    MatchSchedule,
+    Organization,
+    OrganizationEvent,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_match_data():
+    async with AsyncSessionLocal() as session:
+        event = FRCEvent(
+            event_key="2024export",
+            event_name="Export Event",
+            short_name="Export",
+            year=2024,
+            week=1,
+        )
+        organization = Organization(name="Export Org", team_number=9999)
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="export@example.com",
+            auth_provider="discord",
+            display_name="Export User",
+            logged_in_user_org=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+        teams = [
+            TeamRecord(teamNumber=1111, teamName="Team 1111"),
+            TeamRecord(teamNumber=2222, teamName="Team 2222"),
+            TeamRecord(teamNumber=3333, teamName="Team 3333"),
+            TeamRecord(teamNumber=4444, teamName="Team 4444"),
+            TeamRecord(teamNumber=5555, teamName="Team 5555"),
+            TeamRecord(teamNumber=6666, teamName="Team 6666"),
+            TeamRecord(teamNumber=7777, teamName="Team 7777"),
+            TeamRecord(teamNumber=8888, teamName="Team 8888"),
+            TeamRecord(teamNumber=9998, teamName="Team 9998"),
+        ]
+
+        session.add_all([event, organization, user, *teams])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+
+        matches = [
+            MatchSchedule(
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                red1_id=1111,
+                red2_id=2222,
+                red3_id=3333,
+                blue1_id=4444,
+                blue2_id=5555,
+                blue3_id=6666,
+            ),
+            MatchSchedule(
+                event_key=event.event_key,
+                match_number=2,
+                match_level="qm",
+                red1_id=7777,
+                red2_id=8888,
+                red3_id=9998,
+                blue1_id=1111,
+                blue2_id=2222,
+                blue3_id=3333,
+            ),
+        ]
+
+        session.add(organization_event)
+        session.add_all(matches)
+        await session.commit()
+
+        return user_id, membership.id, event.event_key
+
+
+@pytest.fixture(scope="module")
+def prepared_match_export_data(setup_database):
+    return asyncio.run(_prepare_match_data())
+
+
+@pytest.fixture
+def authorized_client(prepared_match_export_data):
+    user_id, membership_id, event_key = prepared_match_export_data
+
+    async def override_current_user():
+        return {
+            "id": str(user_id),
+            "displayName": "Export User",
+            "email": "export@example.com",
+            "user_org": membership_id,
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client, event_key
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_export_matches_as_csv(authorized_client):
+    client, event_key = authorized_client
+    response = client.post("/event/matches/export", json={"file_type": "csv"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert response.headers["content-disposition"].endswith(f'{event_key}_matches.csv"')
+
+    rows = response.text.strip().splitlines()
+    assert len(rows) == 3  # header + two matches
+    assert "match_number" in rows[0]
+    assert "qm" in rows[1]
+
+
+def test_export_matches_as_json(authorized_client):
+    client, event_key = authorized_client
+    response = client.post("/event/matches/export", json={"file_type": "json"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.headers["content-disposition"].endswith(f'{event_key}_matches.json"')
+
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+    assert all(item["event_key"] == event_key for item in payload)
+
+
+def test_export_matches_as_xls(authorized_client):
+    client, event_key = authorized_client
+    response = client.post("/event/matches/export", json={"file_type": "xls"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/vnd.ms-excel")
+    assert response.headers["content-disposition"].endswith(f'{event_key}_matches.xls"')
+    assert "<table" in response.text
+    assert "Team 1111" in response.text
+
+
+def test_export_matches_with_invalid_type(authorized_client):
+    client, _ = authorized_client
+    response = client.post("/event/matches/export", json={"file_type": "txt"})
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- introduce a match export request model that supports csv, json, and xls formats
- add an /event/matches/export endpoint that returns the active event schedule in the requested format
- cover the export endpoint with tests for csv, json, xls responses and invalid file types

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d5f2592e808326997419b8814763cc