### PR TITLE
Move match export to organization download endpoint

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -1,9 +1,4 @@
-import csv
-import io
-import json
-from html import escape
-
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
 from db.database import get_session
@@ -36,58 +31,6 @@ async def get_match_schedule(
 ) -> List[MatchScheduleResponse]:
     event_code = await get_active_event_key_for_user(session, user)
     return await get_match_schedule_or_404(session, event_code)
-
-
-@router.post("/matches/export")
-async def export_match_schedule(
-    request: MatchExportRequest,
-    session: AsyncSession = Depends(get_session),
-    user=Depends(get_current_user),
-) -> Response:
-    event_code = await get_active_event_key_for_user(session, user)
-    matches = await get_match_schedule_or_404(session, event_code)
-    match_dicts = [match.dict() for match in matches]
-
-    if not match_dicts:
-        raise HTTPException(status_code=404, detail="No matches available to export")
-
-    if request.file_type == MatchExportType.CSV:
-        buffer = io.StringIO()
-        writer = csv.DictWriter(buffer, fieldnames=match_dicts[0].keys())
-        writer.writeheader()
-        writer.writerows(match_dicts)
-        content = buffer.getvalue()
-        media_type = "text/csv"
-        extension = "csv"
-    elif request.file_type == MatchExportType.JSON:
-        content = json.dumps(match_dicts, indent=2)
-        media_type = "application/json"
-        extension = "json"
-    elif request.file_type == MatchExportType.XLS:
-        headers = match_dicts[0].keys()
-        header_row = "".join(f"<th>{escape(str(column))}</th>" for column in headers)
-        body_rows = "".join(
-            "<tr>" + "".join(
-                f"<td>{escape(str(row[column]))}</td>" for column in headers
-            ) + "</tr>"
-            for row in match_dicts
-        )
-        content = (
-            "<html><head><meta charset='utf-8'></head><body>"
-            f"<table><thead><tr>{header_row}</tr></thead><tbody>{body_rows}</tbody></table>"
-            "</body></html>"
-        )
-        media_type = "application/vnd.ms-excel"
-        extension = "xls"
-    else:
-        raise HTTPException(status_code=400, detail="Unsupported file type")
-
-    headers = {
-        "Content-Disposition": f'attachment; filename="{event_code}_matches.{extension}"'
-    }
-
-    return Response(content=content, media_type=media_type, headers=headers)
-
 
 @router.get("/organizations")
 async def get_event_organizations(


### PR DESCRIPTION
## Summary
- move the match export endpoint under /organization/downloadData and have it return MatchData records
- add helpers for selecting and serializing match data for export
- update tests to seed match data and validate the new download workflow

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d5f9b31b708326a6851f97319e9090