### PR TITLE
Add team match data endpoint

### DIFF
--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -1,8 +1,12 @@
 from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from auth.dependencies import get_current_user
 from db.database import get_session
-from services.team import get_team_or_404
+from services.team import (
+    get_match_data_for_team_at_active_event,
+    get_team_or_404,
+)
 
 router = APIRouter(
     prefix="/teams",
@@ -13,3 +17,12 @@ router = APIRouter(
 @router.get("/{teamNumber}/info")
 async def get_team_info(teamNumber: int, session: AsyncSession = Depends(get_session)):
     return await get_team_or_404(session, teamNumber)
+
+
+@router.get("/{teamNumber}/matchData")
+async def get_team_match_data(
+    teamNumber: int,
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_match_data_for_team_at_active_event(session, teamNumber, user)

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -2,7 +2,12 @@ from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import TeamRecord
+from models import TeamRecord, UserOrganization
+from services.event import (
+    MATCH_DATA_MODELS_BY_YEAR,
+    get_active_event_key_for_user,
+    get_event_or_404,
+)
 
 
 async def get_team_or_404(session: AsyncSession, team_number: int) -> TeamRecord:
@@ -12,3 +17,29 @@ async def get_team_or_404(session: AsyncSession, team_number: int) -> TeamRecord
     if team is None:
         raise HTTPException(status_code=404, detail="Team not found")
     return team
+
+
+async def get_match_data_for_team_at_active_event(
+    session: AsyncSession,
+    team_number: int,
+    user: dict,
+):
+    event_key = await get_active_event_key_for_user(session, user)
+    event = await get_event_or_404(session, event_key)
+
+    membership_id = user.get("user_org")
+    membership = await session.get(UserOrganization, membership_id)
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Organization membership not found")
+
+    match_model = MATCH_DATA_MODELS_BY_YEAR.get(event.year)
+    if match_model is None:
+        raise HTTPException(status_code=404, detail="Match data is not available for this event")
+
+    statement = select(match_model).where(
+        match_model.team_number == team_number,
+        match_model.event_key == event_key,
+        match_model.organization_id == membership.organization_id,
+    )
+    result = await session.execute(statement)
+    return result.scalars().all()


### PR DESCRIPTION
## Summary
- expose a /teams/{teamNumber}/matchData endpoint under the Team router
- look up the signed-in user's active organization event and fetch match data for the requested team
- restrict the query to the organization's records for the active event season

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d5ffdca20c8326852647805488a654