### PR TITLE
Add scout data validation endpoint

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Body, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
 from db.database import get_session
-from typing import List
+from typing import List, Optional
+
+from models import DataValidation
 
 router = APIRouter(
     prefix="/scout",
@@ -10,6 +12,15 @@ router = APIRouter(
 )
 
 from services.scout import *
+
+
+@router.get("/dataValidation", response_model=List[DataValidation])
+async def get_data_validation_records(
+    filters: Optional[DataValidationFilterRequest] = Body(default=None),
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_data_validations_for_active_event(session, user, filters)
 
 @router.get("/matches/{eventCode}")
 async def get_scouted_matches(

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1,17 +1,81 @@
 from fastapi import HTTPException
+from sqlalchemy import and_
 from sqlmodel import select, delete, SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 from uuid import UUID
-from typing import List
+from typing import List, Optional
 
 from models import (
+    DataValidation,
     MatchData,
     MatchData2025,
     MatchData2026,
     UserOrganization,
-    User, 
+    User,
     Organization
 )
+
+from services.event import (
+    MATCH_DATA_MODELS_BY_YEAR,
+    get_active_event_key_for_user,
+    get_event_or_404,
+)
+
+
+class DataValidationFilterRequest(SQLModel):
+    matchNumber: Optional[int] = None
+    matchLevel: Optional[str] = None
+    teamNumber: Optional[int] = None
+
+
+async def get_data_validations_for_active_event(
+    session: AsyncSession,
+    user: dict,
+    filters: Optional[DataValidationFilterRequest] = None,
+) -> List[DataValidation]:
+    event_key = await get_active_event_key_for_user(session, user)
+
+    membership_id = user.get("user_org")
+    if membership_id is None:
+        raise HTTPException(status_code=404, detail="User is not logged into an organization")
+
+    membership = await session.get(UserOrganization, membership_id)
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Organization membership not found")
+
+    statement = select(DataValidation).where(
+        DataValidation.event_key == event_key,
+        DataValidation.organization_id == membership.organization_id,
+    )
+
+    event = None
+
+    if filters:
+        if filters.matchNumber is not None:
+            statement = statement.where(DataValidation.match_number == filters.matchNumber)
+        if filters.matchLevel:
+            statement = statement.where(DataValidation.match_level == filters.matchLevel)
+        if filters.teamNumber is not None:
+            if event is None:
+                event = await get_event_or_404(session, event_key)
+
+            match_model = MATCH_DATA_MODELS_BY_YEAR.get(event.year)
+            if match_model is None:
+                raise HTTPException(status_code=404, detail="Match data is not available for this event")
+
+            join_condition = and_(
+                match_model.event_key == DataValidation.event_key,
+                match_model.match_number == DataValidation.match_number,
+                match_model.match_level == DataValidation.match_level,
+                match_model.organization_id == DataValidation.organization_id,
+            )
+            statement = (
+                statement.join(match_model, join_condition)
+                .where(match_model.team_number == filters.teamNumber)
+            )
+
+    result = await session.execute(statement)
+    return result.unique().scalars().all()
 
 async def get_already_scouted_matches(session: AsyncSession, eventCode: str, user):
     #check if user is part of an organization that has the orgEvent


### PR DESCRIPTION
## Summary
- add a GET /scout/dataValidation endpoint that returns data validation entries for the active user event with optional filters
- implement service logic to fetch DataValidation records scoped to the logged-in organization and support match and team filters

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d6a82f48088326819a0cffd004d9b4