### PR TITLE
Use membership guest event key for guest active event lookup

### DIFF
--- a/app/models/organization_event.py
+++ b/app/models/organization_event.py
@@ -1,6 +1,5 @@
-from sqlmodel import SQLModel, Field, Relationship
+from sqlmodel import SQLModel, Field
 from uuid import UUID, uuid4
-from typing import Optional
 
 class OrganizationEvent(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -238,4 +238,7 @@ async def get_active_event_key_for_user(
             detail="No active event configured for this organization",
         )
 
+    if membership.role == UserRole.GUEST and membership.event_key:
+        return membership.event_key
+
     return active_event.event_key


### PR DESCRIPTION
## Summary
- drop the unused guest event key column from organization events
- return the user organization's guest event key for guest members when looking up the active event

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*


------
https://chatgpt.com/codex/tasks/task_e_68d6aa9735888326b1ad3d67f3a2bbfa