### PR TITLE
Use active event for scout match queries

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -22,34 +22,13 @@ async def get_data_validation_records(
 ):
     return await get_data_validations_for_active_event(session, user, filters)
 
-@router.get("/matches/{eventCode}")
+@router.get("/matches")
 async def get_scouted_matches(
-    eventCode: str,
+    filters: Optional[ScoutMatchFilterRequest] = Body(default=None),
     user=Depends(get_current_user),
     session: AsyncSession = Depends(get_session)
 ):
-    return await get_already_scouted_matches(session, eventCode, user)
-
-@router.get("/matches/{eventCode}/match/{matchLevel}/{matchNumber}")
-async def get_scouted_match(
-    eventCode: str,
-    matchLevel: str,
-    matchNumber: int,
-    user=Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
-):
-    return await get_already_scouted_match(session, eventCode, matchLevel, matchNumber, user)
-
-@router.get("/matches/{eventCode}/match/{matchLevel}/{matchNumber}/{teamNumber}")
-async def get_scouted_team_match(
-    eventCode: str,
-    matchLevel: str,
-    matchNumber: int,
-    teamNumber: int,
-    user=Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
-):
-    return await get_already_scouted_match(session, eventCode, matchLevel, matchNumber, user, teamNumber)
+    return await get_already_scouted_matches(session, user, filters)
 
 @router.post("/submit/batch")
 async def submit_multiple_matches(


### PR DESCRIPTION
## Summary
- update the scout matches endpoint to rely on the authenticated user's active event
- support optional match, level, and team filters in the scout matches response to replace single-match endpoints

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d6acc6de188326bee1d5597812000e