### PR TITLE
Add batch update endpoint for data validation records

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -4,14 +4,24 @@ from auth.dependencies import get_current_user
 from db.database import get_session
 from typing import List, Optional
 
-from models import DataValidation
+from models import DataValidation, MatchData
 
 router = APIRouter(
     prefix="/scout",
     tags=["Scout"],
 )
 
-from services.scout import *
+from services.scout import (
+    DataValidationFilterRequest,
+    DataValidationUpdateRequest,
+    ScoutMatchFilterRequest,
+    batch_submit_match,
+    batch_update_data_validations,
+    batch_update_match,
+    get_already_scouted_matches,
+    get_data_validations_for_active_event,
+    submit_scouted_match,
+)
 
 
 @router.get("/dataValidation", response_model=List[DataValidation])
@@ -21,6 +31,15 @@ async def get_data_validation_records(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_data_validations_for_active_event(session, user, filters)
+
+
+@router.patch("/dataValidation", response_model=List[DataValidation])
+async def update_data_validation_records(
+    updates: List[DataValidationUpdateRequest],
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await batch_update_data_validations(session, user, updates)
 
 @router.get("/matches")
 async def get_scouted_matches(


### PR DESCRIPTION
## Summary
- add a request model and service function to batch update data validation records
- expose a PATCH /scout/dataValidation endpoint that updates validation status and notes without requiring timestamps

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d6d93a38ac8326b8c5324a02e3c87b