### PR TITLE
Refactor TBA match data models

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,6 +12,7 @@ from .organization import Organization
 from .organization_event import OrganizationEvent
 from .organization_feature_settings import OrganizationFeatureSettings
 from .robot_event_image_link import RobotEventImageLink
+from .tba_match_data import Alliance, TBAMatchData
 from .tba_match_data_2025 import TBAMatchData2025
 from .team_at_event import TeamEvent
 from .user import User

--- a/app/models/tba_match_data.py
+++ b/app/models/tba_match_data.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from enum import Enum
+
+from sqlmodel import Field, SQLModel
+
+
+class Alliance(str, Enum):
+    RED = "RED"
+    BLUE = "BLUE"
+
+
+class TBAMatchData(SQLModel):
+    """Base fields shared by TBA match data tables."""
+
+    event_key: str = Field(
+        foreign_key="frcevent.event_key",
+        primary_key=True,
+        max_length=15,
+    )
+    match_number: int = Field(primary_key=True)
+    match_level: str = Field(primary_key=True, max_length=50)
+    alliance: Alliance = Field(primary_key=True)
+    timestamp: datetime = Field(default_factory=datetime.now)

--- a/app/models/tba_match_data_2025.py
+++ b/app/models/tba_match_data_2025.py
@@ -1,7 +1,9 @@
-from sqlmodel import SQLModel, Field, Relationship
-from typing import Optional
-from datetime import datetime
 from enum import Enum
+
+from sqlmodel import Field
+
+from .tba_match_data import Alliance, TBAMatchData
+
 
 class Endgame2025(str, Enum):
     NONE = "NONE"
@@ -9,25 +11,9 @@ class Endgame2025(str, Enum):
     SHALLOW = "SHALLOW"
     DEEP = "DEEP"
 
-class Alliance(str, Enum):
-    RED="RED"
-    BLUE="BLUE"
 
-class TBAMatchData2025(SQLModel, table=True):
-    team_number: int = Field(
-        foreign_key="teamrecord.team_number", 
-        primary_key=True
-    )
-    event_key: str = Field(
-        foreign_key="frcevent.event_key", 
-        primary_key=True, 
-        max_length=15
-    )
-    match_number: int = Field(primary_key=True)
-    match_level: str = Field(primary_key=True, max_length=50)
-    alliance: Alliance = Field(primary_key=True, default=Alliance.RED)
-    timestamp: datetime = Field(default_factory=datetime.now())
-
+class TBAMatchData2025(TBAMatchData, table=True):
+    __tablename__ = "tbamatchdata2025"
 
     # Autonomous Levels
     al4c: int = Field(default=0)
@@ -49,4 +35,3 @@ class TBAMatchData2025(SQLModel, table=True):
 
     # Endgame
     endgame: Endgame2025 = Field(default=Endgame2025.NONE)
-    


### PR DESCRIPTION
## Summary
- add a shared `TBAMatchData` base model that defines core primary key fields and timestamp handling for TBA match data tables
- update the 2025 TBA match data model to inherit from the shared base and drop the team number column
- expose the new base model and alliance enum via the models package for reuse

## Testing
- pytest *(fails: missing optional dependency `sqlmodel` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dab7c23c8326960701c5d854e048