### PR TITLE
Implement match edit validation for 2025 and 2026 seasons

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1,7 +1,7 @@
 import os
 from collections import defaultdict
 from enum import Enum as PyEnum
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Callable, Sequence, cast
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Callable, Sequence, TypeVar, cast
 
 import httpx
 from fastapi import HTTPException
@@ -36,6 +36,8 @@ from services.event import (
 
 TBA_API_BASE_URL = "https://www.thebluealliance.com/api/v3"
 TBA_API_KEY_ENV_VAR = "TBA_API_KEY"
+
+MatchDataType = TypeVar("MatchDataType", bound=MatchData)
 
 TBA_MATCH_DATA_MODELS_BY_YEAR: Dict[int, type[TBAMatchData]] = {
     2025: TBAMatchData2025,
@@ -944,11 +946,149 @@ async def _submit_match_for_year(
 async def submit_2025_match(session: AsyncSession, match: MatchData2025, user: User) -> None:
     await _submit_match_for_year(session, match, user, expected_year=2025, match_model=MatchData2025)
 
+
+async def _edit_match_for_year(
+    session: AsyncSession,
+    match: MatchData,
+    user: User,
+    *,
+    expected_year: int,
+    match_model: type[MatchDataType],
+) -> MatchDataType:
+    match_payload = _model_dump(match)
+    try:
+        base_match = _model_validate(MatchData, match_payload)
+    except ValidationError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=422, detail="Invalid match data payload") from exc
+
+    user_id: Optional[UUID] = getattr(user, "id", None)
+    if user_id is None and isinstance(user, dict):
+        raw_user_id = user.get("id")
+        if raw_user_id is not None:
+            user_id = cast(Optional[UUID], raw_user_id)
+
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    if isinstance(user_id, str):
+        try:
+            user_id = UUID(user_id)
+        except ValueError as exc:  # pragma: no cover - defensive programming
+            raise HTTPException(status_code=400, detail="Invalid user identifier") from exc
+
+    membership_id: Optional[Any] = getattr(user, "logged_in_user_org", None)
+    if membership_id is None and isinstance(user, dict):
+        membership_id = user.get("logged_in_user_org")
+        if membership_id is None:
+            membership_id = user.get("user_org")
+
+    if membership_id is None:
+        raise HTTPException(status_code=404, detail="User is not logged into an organization")
+
+    if isinstance(membership_id, str):
+        try:
+            membership_id = int(membership_id)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid organization membership identifier",
+            ) from exc
+
+    membership = await session.get(UserOrganization, membership_id)
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Organization membership not found")
+
+    if membership.user_id != user_id:
+        raise HTTPException(status_code=403, detail="User does not belong to this organization")
+
+    if base_match.organization_id != membership.organization_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Match data does not belong to the active organization",
+        )
+
+    event = await get_event_or_404(session, base_match.event_key)
+    if event.year != expected_year:
+        raise HTTPException(
+            status_code=400,
+            detail="Match data event does not match the expected season year",
+        )
+
+    season = await session.get(Season, base_match.season)
+    if season is None:
+        raise HTTPException(status_code=404, detail="Season not found for provided match data")
+
+    if season.year != expected_year:
+        raise HTTPException(
+            status_code=400,
+            detail="Match data season does not match the expected season year",
+        )
+
+    match_user_id = getattr(base_match, "user_id", None)
+    if match_user_id and match_user_id != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Match data user does not match the authenticated user",
+        )
+
+    payload: Dict[str, Any] = {
+        **match_payload,
+        "user_id": user_id,
+        "organization_id": membership.organization_id,
+    }
+    payload["notes"] = payload.get("notes") or ""
+    payload.pop("timestamp", None)
+
+    try:
+        typed_match = cast(MatchDataType, _model_validate(match_model, payload))
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail="Invalid match data for this season") from exc
+
+    statement = select(match_model).where(
+        match_model.event_key == getattr(typed_match, "event_key"),
+        match_model.match_number == getattr(typed_match, "match_number"),
+        match_model.match_level == getattr(typed_match, "match_level"),
+        match_model.team_number == getattr(typed_match, "team_number"),
+        match_model.user_id == getattr(typed_match, "user_id"),
+        match_model.organization_id == getattr(typed_match, "organization_id"),
+    )
+    result = await session.execute(statement)
+    existing_match = result.scalars().first()
+
+    if existing_match is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Match data has not been submitted for this match",
+        )
+
+    for field_name in _get_model_field_names(match_model):
+        setattr(existing_match, field_name, getattr(typed_match, field_name))
+
+    session.add(existing_match)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Match data conflicts with an existing submission for this match",
+        ) from exc
+
+    await session.refresh(existing_match)
+    return cast(MatchDataType, existing_match)
+
+async def edit_2025_match(session: AsyncSession, match: MatchData2025, user: User) -> MatchData2025:
+    return await _edit_match_for_year(session, match, user, expected_year=2025, match_model=MatchData2025)
+
 async def update_2025_match(session: AsyncSession, match: MatchData2025, user: User) -> None:
-    pass
+    await edit_2025_match(session, match, user)
 
 async def submit_2026_match(session: AsyncSession, match: MatchData2026, user: User) -> None:
     await _submit_match_for_year(session, match, user, expected_year=2026, match_model=MatchData2026)
 
+async def edit_2026_match(session: AsyncSession, match: MatchData2026, user: User) -> MatchData2026:
+    return await _edit_match_for_year(session, match, user, expected_year=2026, match_model=MatchData2026)
+
 async def update_2026_match(session: AsyncSession, match: MatchData2026, user: User) -> None:
-    pass
+    await edit_2026_match(session, match, user)


### PR DESCRIPTION
## Summary
- add a reusable helper that validates organizations, users, and seasons when editing match data
- implement season-specific edit functions for 2025 and 2026 that reuse the shared helper and ensure updates are persisted
- reuse the new edit logic from the existing update entry points

## Testing
- pytest *(fails: missing dependency `sqlmodel` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d74716349c8326b0411e5078eb21e7