### PR TITLE
Refactor scout data validation update flow

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
 from db.database import get_session
 from typing import List, Optional
+from uuid import UUID
 
-from models import DataValidation, MatchData
+from sqlmodel import select
+
+from models import DataValidation, MatchData, Season, ValidationStatus
+from services.event import MATCH_DATA_MODELS_BY_YEAR
 
 router = APIRouter(
     prefix="/scout",
@@ -21,7 +25,7 @@ from services.scout import (
     get_already_scouted_matches,
     get_data_validations_for_active_event,
     submit_scouted_match,
-    update_match_data_and_mark_validation_valid,
+    update_scouted_match,
     update_tba_match_data_for_pending_alliances,
 )
 
@@ -50,7 +54,64 @@ async def mark_match_data_valid(
     user=Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-    return await update_match_data_and_mark_validation_valid(session, user, match)
+    match_payload = match.model_dump()
+    requested_notes = match_payload.get("notes")
+
+    season = await session.get(Season, match.season)
+    if season is None:
+        raise HTTPException(status_code=404, detail="Season not found for provided match data")
+
+    match_model = MATCH_DATA_MODELS_BY_YEAR.get(season.year)
+    if match_model is None:
+        raise HTTPException(status_code=404, detail="Match data is not available for this event")
+
+    user_id: UUID = match.user_id if isinstance(match.user_id, UUID) else UUID(str(match.user_id))
+
+    statement = select(match_model).where(
+        match_model.event_key == match.event_key,
+        match_model.match_number == match.match_number,
+        match_model.match_level == match.match_level,
+        match_model.team_number == match.team_number,
+        match_model.user_id == user_id,
+        match_model.organization_id == match.organization_id,
+    )
+
+    result = await session.execute(statement)
+    stored_match = result.scalars().first()
+
+    if stored_match is None:
+        raise HTTPException(status_code=404, detail="Match data not found for the provided identifiers")
+
+    dummy_payload = {**match_payload, "notes": stored_match.notes or ""}
+
+    dummy_match = match_model(**dummy_payload)
+
+    await update_scouted_match(session, dummy_match, user)
+
+    validation_stmt = select(DataValidation).where(
+        DataValidation.event_key == match.event_key,
+        DataValidation.match_number == match.match_number,
+        DataValidation.match_level == match.match_level,
+        DataValidation.team_number == match.team_number,
+        DataValidation.user_id == user_id,
+        DataValidation.organization_id == match.organization_id,
+    )
+
+    validation_result = await session.execute(validation_stmt)
+    validation = validation_result.scalars().first()
+
+    if validation is None:
+        raise HTTPException(status_code=404, detail="Data validation record not found for this match")
+
+    validation.validation_status = ValidationStatus.VALID
+    if "notes" in match_payload:
+        validation.notes = (requested_notes or "") if requested_notes is not None else ""
+
+    session.add(validation)
+    await session.commit()
+    await session.refresh(validation)
+
+    return validation
 
 
 @router.post("/data/tbaUpdate")


### PR DESCRIPTION
## Summary
- update the `/scout/dataValidation` PUT handler to load the stored match, preserve its notes, and drive updates through `update_scouted_match`
- expand scout service utilities to share match update preparation logic and reuse it from the route handler

## Testing
- `pytest tests/test_data_validation_update.py::test_put_data_validation_updates_match_and_status` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68d747e38c0c8326883f319966bb6ad7