### PR TITLE
Move team event summary endpoint to analytics namespace

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routes import admin, user, event, organizationadmin, user, scout, team, season
+from routes import admin, analytics, event, organizationadmin, user, scout, team, season
 
 # Create FastAPI app
 app = FastAPI(title="Scouting App API")
@@ -18,10 +18,10 @@ app.add_middleware(
 )
 
 app.include_router(admin.router)
+app.include_router(analytics.router)
 app.include_router(user.router)
 app.include_router(event.router)
 app.include_router(organizationadmin.router)
-app.include_router(user.router)
 app.include_router(scout.router)
 app.include_router(team.router)
 app.include_router(season.router)

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from auth.dependencies import get_current_user
+from db.database import get_session
+from services.analytics.event_summary import (
+    TeamEventSummary,
+    get_team_event_summary,
+)
+
+router = APIRouter(
+    prefix="/analytics",
+    tags=["Analytics"],
+)
+
+
+@router.get("/eventSummary/teams", response_model=List[TeamEventSummary])
+async def summarize_event_by_team(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_team_event_summary(session, user)

--- a/app/services/analytics/__init__.py
+++ b/app/services/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics service package."""

--- a/app/services/analytics/event_summary.py
+++ b/app/services/analytics/event_summary.py
@@ -1,0 +1,278 @@
+"""Utilities for summarizing event match data using pandas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+import pandas as pd
+from fastapi import HTTPException
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from models import (
+    UserOrganization,
+)
+from ..event import (
+    MATCH_DATA_MODELS_BY_YEAR,
+    get_active_event_key_for_user,
+    get_event_or_404,
+)
+
+
+@dataclass(frozen=True)
+class YearlyScoringConfig:
+    """Defines how to score match data for a specific game year."""
+
+    auto_weights: Mapping[str, float]
+    teleop_weights: Mapping[str, float]
+    endgame_points: Mapping[str, float]
+    game_piece_fields: Sequence[str]
+
+
+def _default_yearly_configs() -> Dict[int, YearlyScoringConfig]:
+    """Return the scoring configuration for each supported year."""
+
+    return {
+        2025: YearlyScoringConfig(
+            auto_weights={
+                "al4c": 6.0,
+                "al3c": 5.0,
+                "al2c": 4.0,
+                "al1c": 3.0,
+                "aNet": 4.0,
+                "aProcessor": 8.0,
+            },
+            teleop_weights={
+                "tl4c": 5.0,
+                "tl3c": 4.0,
+                "tl2c": 3.0,
+                "tl1c": 2.0,
+                "tNet": 2.0,
+                "tProcessor": 6.0,
+            },
+            endgame_points={
+                "NONE": 0.0,
+                "PARK": 2.0,
+                "SHALLOW": 6.0,
+                "DEEP": 12.0,
+            },
+            game_piece_fields=(
+                "al4c",
+                "al3c",
+                "al2c",
+                "al1c",
+                "aNet",
+                "aProcessor",
+                "tl4c",
+                "tl3c",
+                "tl2c",
+                "tl1c",
+                "tNet",
+                "tProcessor",
+            ),
+        ),
+        2026: YearlyScoringConfig(
+            auto_weights={},
+            teleop_weights={},
+            endgame_points={"NONE": 0.0},
+            game_piece_fields=(),
+        ),
+    }
+
+
+SCORING_CONFIGS: Dict[int, YearlyScoringConfig] = _default_yearly_configs()
+
+
+class TeamEventSummary(SQLModel):
+    team_number: int
+    matches_played: int
+    autonomous_points_average: float
+    teleop_points_average: float
+    endgame_points_average: float
+    game_piece_average: float
+    total_points_average: float
+
+
+def _normalize_user_payload(user: object) -> Dict[str, object]:
+    if isinstance(user, dict):
+        return user
+
+    return {
+        "id": getattr(user, "id", None),
+        "user_org": getattr(user, "logged_in_user_org", None),
+    }
+
+
+def _coerce_membership_id(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    raise HTTPException(status_code=400, detail="Invalid organization membership identifier")
+
+
+async def _get_membership(session: AsyncSession, user_payload: Dict[str, object]) -> UserOrganization:
+    membership_id = user_payload.get("user_org")
+    if membership_id is None:
+        raise HTTPException(status_code=404, detail="User is not logged into an organization")
+
+    membership = await session.get(UserOrganization, _coerce_membership_id(membership_id))
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Organization membership not found")
+    return membership
+
+
+def _weighted_sum(df: pd.DataFrame, weights: Mapping[str, float]) -> pd.Series:
+    if df.empty:
+        return pd.Series(dtype=float)
+
+    total = pd.Series(0.0, index=df.index, dtype=float)
+    for field, weight in weights.items():
+        if field not in df.columns:
+            continue
+        values = pd.to_numeric(df[field], errors="coerce").fillna(0.0)
+        total = total + values * weight
+    return total
+
+
+def _calculate_game_piece_counts(df: pd.DataFrame, fields: Iterable[str]) -> pd.Series:
+    if df.empty:
+        return pd.Series(dtype=float)
+
+    total = pd.Series(0.0, index=df.index, dtype=float)
+    for field in fields:
+        if field not in df.columns:
+            continue
+        values = pd.to_numeric(df[field], errors="coerce").fillna(0.0)
+        total = total + values
+    return total
+
+
+def _normalize_endgame_value(value: object) -> str:
+    if hasattr(value, "value"):
+        value = getattr(value, "value")
+    if isinstance(value, str):
+        normalized = value.strip().upper()
+        return normalized or "NONE"
+    return "NONE"
+
+
+def _endgame_points(df: pd.DataFrame, config: YearlyScoringConfig) -> pd.Series:
+    if df.empty or "endgame" not in df.columns:
+        return pd.Series(dtype=float)
+
+    normalized = df["endgame"].map(_normalize_endgame_value)
+    return normalized.map(lambda value: config.endgame_points.get(value, 0.0)).astype(float)
+
+
+def _collect_scoring_fields(config: YearlyScoringConfig) -> Sequence[str]:
+    fields = set(config.game_piece_fields)
+    fields.update(config.auto_weights.keys())
+    fields.update(config.teleop_weights.keys())
+    return sorted(fields)
+
+
+def _records_to_dataframe(records: Sequence[SQLModel], config: YearlyScoringConfig) -> pd.DataFrame:
+    scoring_fields = _collect_scoring_fields(config)
+
+    rows = []
+    for record in records:
+        row = {
+            "team_number": getattr(record, "team_number", None),
+            "match_number": getattr(record, "match_number", None),
+            "endgame": getattr(record, "endgame", None),
+        }
+
+        for field in scoring_fields:
+            row[field] = getattr(record, field, 0) or 0
+
+        rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def _summarize_by_team(df: pd.DataFrame, config: YearlyScoringConfig) -> List[Dict[str, object]]:
+    if df.empty:
+        return []
+
+    df = df.copy()
+    df["autonomous_points"] = _weighted_sum(df, config.auto_weights)
+    df["teleop_points"] = _weighted_sum(df, config.teleop_weights)
+    df["endgame_points"] = _endgame_points(df, config)
+    df["game_piece_count"] = _calculate_game_piece_counts(df, config.game_piece_fields)
+    df["total_points"] = (
+        df["autonomous_points"] + df["teleop_points"] + df["endgame_points"]
+    )
+
+    summary = (
+        df.groupby("team_number")
+        .agg(
+            matches_played=("match_number", "count"),
+            autonomous_points_average=("autonomous_points", "mean"),
+            teleop_points_average=("teleop_points", "mean"),
+            endgame_points_average=("endgame_points", "mean"),
+            game_piece_average=("game_piece_count", "mean"),
+            total_points_average=("total_points", "mean"),
+        )
+        .reset_index()
+        .sort_values("team_number")
+    )
+
+    for column in [
+        "autonomous_points_average",
+        "teleop_points_average",
+        "endgame_points_average",
+        "game_piece_average",
+        "total_points_average",
+    ]:
+        summary[column] = summary[column].fillna(0.0).round(2)
+
+    summary["matches_played"] = summary["matches_played"].fillna(0).astype(int)
+    summary["team_number"] = summary["team_number"].fillna(0).astype(int)
+
+    return summary.to_dict(orient="records")
+
+
+async def get_team_event_summary(
+    session: AsyncSession,
+    user: object,
+) -> List[TeamEventSummary]:
+    user_payload = _normalize_user_payload(user)
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+    membership = await _get_membership(session, user_payload)
+
+    match_model = MATCH_DATA_MODELS_BY_YEAR.get(event.year)
+    if match_model is None:
+        raise HTTPException(status_code=404, detail="Match data is not available for this event")
+
+    scoring_config = SCORING_CONFIGS.get(event.year)
+    if (
+        scoring_config is None
+        or (
+            not scoring_config.auto_weights
+            and not scoring_config.teleop_weights
+            and not scoring_config.game_piece_fields
+        )
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail="Team summaries are not configured for this event year",
+        )
+
+    statement = select(match_model).where(
+        match_model.event_key == event_key,
+        match_model.organization_id == membership.organization_id,
+    )
+    result = await session.execute(statement)
+    records = result.scalars().all()
+
+    if not records:
+        return []
+
+    dataframe = _records_to_dataframe(records, scoring_config)
+    summaries = _summarize_by_team(dataframe, scoring_config)
+    return [TeamEventSummary(**row) for row in summaries]
+
+

--- a/tests/test_team_event_summary.py
+++ b/tests/test_team_event_summary.py
@@ -1,0 +1,183 @@
+import asyncio
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependencies import get_current_user
+from app.main import app
+from app.models import (
+    Endgame2025,
+    FRCEvent,
+    MatchData2025,
+    Organization,
+    OrganizationEvent,
+    Season,
+    TeamEvent,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_event_summary_data():
+    async with AsyncSessionLocal() as session:
+        season = Season(id=1, year=2025, name="REEFSCAPE")
+        event = FRCEvent(
+            event_key="2025summary",
+            event_name="Summary Event",
+            short_name="Summary",
+            year=2025,
+            week=2,
+        )
+        organization = Organization(name="Summary Org", team_number=4321)
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="summary@example.com",
+            auth_provider="discord",
+            display_name="Summary User",
+            logged_in_user_org=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+        teams = [
+            TeamRecord(teamNumber=1111, teamName="Team 1111"),
+            TeamRecord(teamNumber=2222, teamName="Team 2222"),
+        ]
+
+        session.add_all([season, event, organization, user, *teams])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        team_entries = [
+            TeamEvent(event_key=event.event_key, team_number=1111),
+            TeamEvent(event_key=event.event_key, team_number=2222),
+        ]
+
+        match_data = [
+            MatchData2025(
+                season=season.id,
+                team_number=1111,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al4c=1,
+                al3c=1,
+                aNet=1,
+                tl4c=2,
+                tNet=1,
+                tProcessor=1,
+                endgame=Endgame2025.SHALLOW,
+            ),
+            MatchData2025(
+                season=season.id,
+                team_number=1111,
+                event_key=event.event_key,
+                match_number=2,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al2c=1,
+                aProcessor=1,
+                tl3c=1,
+                tl1c=2,
+                tProcessor=1,
+                endgame=Endgame2025.PARK,
+            ),
+            MatchData2025(
+                season=season.id,
+                team_number=2222,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al3c=2,
+                aNet=1,
+                tl2c=3,
+                tProcessor=2,
+                endgame=Endgame2025.DEEP,
+            ),
+        ]
+
+        session.add(organization_event)
+        session.add_all(team_entries)
+        session.add_all(match_data)
+        await session.commit()
+
+        return user_id, membership.id
+
+
+@pytest.fixture(scope="module")
+def prepared_event_summary_data(setup_database):
+    return asyncio.run(_prepare_event_summary_data())
+
+
+@pytest.fixture
+def summary_client(prepared_event_summary_data):
+    user_id, membership_id = prepared_event_summary_data
+
+    async def override_current_user():
+        return {
+            "id": str(user_id),
+            "displayName": "Summary User",
+            "email": "summary@example.com",
+            "user_org": membership_id,
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_get_team_event_summary(summary_client):
+    response = summary_client.get("/analytics/eventSummary/teams")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+
+    first, second = payload
+
+    assert first["team_number"] == 1111
+    assert first["matches_played"] == 2
+    assert first["autonomous_points_average"] == pytest.approx(13.5)
+    assert first["teleop_points_average"] == pytest.approx(16.0)
+    assert first["endgame_points_average"] == pytest.approx(4.0)
+    assert first["game_piece_average"] == pytest.approx(6.5)
+    assert first["total_points_average"] == pytest.approx(33.5)
+
+    assert second["team_number"] == 2222
+    assert second["matches_played"] == 1
+    assert second["autonomous_points_average"] == pytest.approx(14.0)
+    assert second["teleop_points_average"] == pytest.approx(21.0)
+    assert second["endgame_points_average"] == pytest.approx(12.0)
+    assert second["game_piece_average"] == pytest.approx(8.0)
+    assert second["total_points_average"] == pytest.approx(47.0)


### PR DESCRIPTION
## Summary
- relocate the team event summary service into an analytics package and register a dedicated router
- expose GET /analytics/eventSummary/teams via the new router while removing the prior scout endpoint
- update the event summary integration test to hit the analytics namespace

## Testing
- `pytest` *(fails: missing aiosqlite dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab75524908326baedd91e77c7cfbd