### PR TITLE
Allow MatchData to retain season-specific fields

### DIFF
--- a/app/models/match_data.py
+++ b/app/models/match_data.py
@@ -4,10 +4,13 @@ from uuid import UUID
 
 from sqlalchemy import event, select
 from sqlmodel import Field, SQLModel
+from pydantic import ConfigDict
 
 
 class MatchData(SQLModel):
     """Base fields shared by all match data tables."""
+
+    model_config = ConfigDict(extra="allow")
 
     season: int = Field(foreign_key="season.id")
     team_number: int = Field(

--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -82,9 +82,16 @@ async def mark_match_data_valid(
     if stored_match is None:
         raise HTTPException(status_code=404, detail="Match data not found for the provided identifiers")
 
-    dummy_payload = {**match_payload, "notes": stored_match.notes or ""}
+    stored_payload = stored_match.model_dump()
 
-    dummy_match = match_model(**dummy_payload)
+    merged_payload = {**stored_payload, **{key: value for key, value in match_payload.items() if key != "notes"}}
+
+    if "notes" in match_payload:
+        merged_payload["notes"] = (requested_notes or "") if requested_notes is not None else ""
+    else:
+        merged_payload["notes"] = stored_payload.get("notes") or ""
+
+    dummy_match = match_model(**merged_payload)
 
     await update_scouted_match(session, dummy_match, user)
 


### PR DESCRIPTION
## Summary
- allow the base MatchData model to keep season-specific fields provided in requests so they persist through validation

## Testing
- not run (missing required database dependency)


------
https://chatgpt.com/codex/tasks/task_e_68dae2508a248326a7555305cf7c0212