### PR TITLE
Add detailed team analytics endpoint

### DIFF
--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -6,7 +6,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
 from db.database import get_session
 from services.analytics.event_summary import (
+    TeamEventDetailedSummary,
     TeamEventSummary,
+    get_team_event_detailed_summary,
     get_team_event_summary,
 )
 
@@ -22,3 +24,14 @@ async def summarize_event_by_team(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_team_event_summary(session, user)
+
+
+@router.get(
+    "/event/teams/detailed",
+    response_model=List[TeamEventDetailedSummary],
+)
+async def summarize_event_by_team_detailed(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_team_event_detailed_summary(session, user)

--- a/app/services/analytics/event_summary.py
+++ b/app/services/analytics/event_summary.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Sequence
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
 import pandas as pd
 from fastapi import HTTPException
@@ -92,6 +92,24 @@ class TeamEventSummary(SQLModel):
     endgame_points_average: float
     game_piece_average: float
     total_points_average: float
+
+
+class DistributionStatistics(SQLModel):
+    min: float = 0.0
+    lowerQuartile: float = 0.0
+    median: float = 0.0
+    upperQuartile: float = 0.0
+    max: float = 0.0
+    average: float = 0.0
+
+
+class TeamEventDetailedSummary(SQLModel):
+    team_number: int
+    matches_played: int
+    autonomous_points: DistributionStatistics
+    teleop_points: DistributionStatistics
+    game_pieces: DistributionStatistics
+    total_points: DistributionStatistics
 
 
 def _normalize_user_payload(user: object) -> Dict[str, object]:
@@ -234,11 +252,74 @@ def _summarize_by_team(df: pd.DataFrame, config: YearlyScoringConfig) -> List[Di
     return summary.to_dict(orient="records")
 
 
-async def get_team_event_summary(
-    session: AsyncSession,
-    user: object,
-) -> List[TeamEventSummary]:
-    user_payload = _normalize_user_payload(user)
+def _round_stat(value: float) -> float:
+    if pd.isna(value):
+        return 0.0
+    return round(float(value), 2)
+
+
+def _calculate_distribution_statistics(series: pd.Series) -> DistributionStatistics:
+    if series.empty:
+        return DistributionStatistics()
+
+    numeric_series = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric_series.empty:
+        return DistributionStatistics()
+
+    return DistributionStatistics(
+        min=_round_stat(numeric_series.min()),
+        lowerQuartile=_round_stat(
+            numeric_series.quantile(0.25, interpolation="linear")
+        ),
+        median=_round_stat(numeric_series.median()),
+        upperQuartile=_round_stat(
+            numeric_series.quantile(0.75, interpolation="linear")
+        ),
+        max=_round_stat(numeric_series.max()),
+        average=_round_stat(numeric_series.mean()),
+    )
+
+
+def _summarize_detailed_by_team(
+    df: pd.DataFrame, config: YearlyScoringConfig
+) -> List[TeamEventDetailedSummary]:
+    if df.empty:
+        return []
+
+    df = df.copy()
+    df["autonomous_points"] = _weighted_sum(df, config.auto_weights)
+    df["teleop_points"] = _weighted_sum(df, config.teleop_weights)
+    df["endgame_points"] = _endgame_points(df, config)
+    df["game_piece_count"] = _calculate_game_piece_counts(df, config.game_piece_fields)
+    df["total_points"] = (
+        df["autonomous_points"] + df["teleop_points"] + df["endgame_points"]
+    )
+
+    summaries: List[TeamEventDetailedSummary] = []
+    grouped = df.groupby("team_number")
+    for team_number, group in grouped:
+        summaries.append(
+            TeamEventDetailedSummary(
+                team_number=int(team_number) if pd.notna(team_number) else 0,
+                matches_played=int(group["match_number"].count()),
+                autonomous_points=_calculate_distribution_statistics(
+                    group["autonomous_points"]
+                ),
+                teleop_points=_calculate_distribution_statistics(group["teleop_points"]),
+                game_pieces=_calculate_distribution_statistics(
+                    group["game_piece_count"]
+                ),
+                total_points=_calculate_distribution_statistics(group["total_points"]),
+            )
+        )
+
+    summaries.sort(key=lambda entry: entry.team_number)
+    return summaries
+
+
+async def _load_event_dataframe(
+    session: AsyncSession, user_payload: Dict[str, object]
+) -> Tuple[pd.DataFrame, YearlyScoringConfig]:
     event_key = await get_active_event_key_for_user(session, user_payload)
     event = await get_event_or_404(session, event_key)
     membership = await _get_membership(session, user_payload)
@@ -269,10 +350,36 @@ async def get_team_event_summary(
     records = result.scalars().all()
 
     if not records:
-        return []
+        return pd.DataFrame(), scoring_config
 
     dataframe = _records_to_dataframe(records, scoring_config)
+    return dataframe, scoring_config
+
+
+async def get_team_event_summary(
+    session: AsyncSession,
+    user: object,
+) -> List[TeamEventSummary]:
+    user_payload = _normalize_user_payload(user)
+    dataframe, scoring_config = await _load_event_dataframe(session, user_payload)
+
+    if dataframe.empty:
+        return []
+
     summaries = _summarize_by_team(dataframe, scoring_config)
     return [TeamEventSummary(**row) for row in summaries]
+
+
+async def get_team_event_detailed_summary(
+    session: AsyncSession,
+    user: object,
+) -> List[TeamEventDetailedSummary]:
+    user_payload = _normalize_user_payload(user)
+    dataframe, scoring_config = await _load_event_dataframe(session, user_payload)
+
+    if dataframe.empty:
+        return []
+
+    return _summarize_detailed_by_team(dataframe, scoring_config)
 
 

--- a/tests/test_team_event_summary.py
+++ b/tests/test_team_event_summary.py
@@ -181,3 +181,69 @@ def test_get_team_event_summary(summary_client):
     assert second["endgame_points_average"] == pytest.approx(12.0)
     assert second["game_piece_average"] == pytest.approx(8.0)
     assert second["total_points_average"] == pytest.approx(47.0)
+
+
+def test_get_team_event_detailed_summary(summary_client):
+    response = summary_client.get("/analytics/event/teams/detailed")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+
+    first, second = payload
+
+    assert first["team_number"] == 1111
+    assert first["matches_played"] == 2
+
+    autonomous = first["autonomous_points"]
+    assert autonomous["min"] == pytest.approx(6.0)
+    assert autonomous["lowerQuartile"] == pytest.approx(8.75)
+    assert autonomous["median"] == pytest.approx(11.5)
+    assert autonomous["upperQuartile"] == pytest.approx(14.25)
+    assert autonomous["max"] == pytest.approx(17.0)
+    assert autonomous["average"] == pytest.approx(11.5)
+
+    teleop = first["teleop_points"]
+    assert teleop["min"] == pytest.approx(10.0)
+    assert teleop["lowerQuartile"] == pytest.approx(11.5)
+    assert teleop["median"] == pytest.approx(13.0)
+    assert teleop["upperQuartile"] == pytest.approx(14.5)
+    assert teleop["max"] == pytest.approx(16.0)
+    assert teleop["average"] == pytest.approx(13.0)
+
+    game_pieces = first["game_pieces"]
+    assert game_pieces["min"] == pytest.approx(6.0)
+    assert game_pieces["lowerQuartile"] == pytest.approx(6.25)
+    assert game_pieces["median"] == pytest.approx(6.5)
+    assert game_pieces["upperQuartile"] == pytest.approx(6.75)
+    assert game_pieces["max"] == pytest.approx(7.0)
+    assert game_pieces["average"] == pytest.approx(6.5)
+
+    total_points = first["total_points"]
+    assert total_points["min"] == pytest.approx(18.0)
+    assert total_points["lowerQuartile"] == pytest.approx(23.25)
+    assert total_points["median"] == pytest.approx(28.5)
+    assert total_points["upperQuartile"] == pytest.approx(33.75)
+    assert total_points["max"] == pytest.approx(39.0)
+    assert total_points["average"] == pytest.approx(28.5)
+
+    assert second["team_number"] == 2222
+    assert second["matches_played"] == 1
+
+    second_auto = second["autonomous_points"]
+    for key in ("min", "lowerQuartile", "median", "upperQuartile", "max", "average"):
+        assert second_auto[key] == pytest.approx(16.0)
+
+    second_teleop = second["teleop_points"]
+    for key in ("min", "lowerQuartile", "median", "upperQuartile", "max", "average"):
+        assert second_teleop[key] == pytest.approx(13.0)
+
+    second_game_pieces = second["game_pieces"]
+    for key in ("min", "lowerQuartile", "median", "upperQuartile", "max", "average"):
+        assert second_game_pieces[key] == pytest.approx(8.0)
+
+    second_total = second["total_points"]
+    for key in ("min", "lowerQuartile", "median", "upperQuartile", "max", "average"):
+        assert second_total[key] == pytest.approx(41.0)


### PR DESCRIPTION
## Summary
- add a detailed `/analytics/event/teams/detailed` endpoint to return per-team distribution metrics
- extend analytics service with shared dataframe loading and distribution helpers
- cover the new endpoint with tests that assert the computed statistics

## Testing
- pytest tests/test_team_event_summary.py *(fails: missing aiosqlite dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dafbbea4748326aa58be1aa21fcfcd