### PR TITLE
Add extended z-score metrics for event analytics

### DIFF
--- a/app/services/analytics/event_summary.py
+++ b/app/services/analytics/event_summary.py
@@ -109,11 +109,37 @@ class TeamEventZScoreSummary(SQLModel):
     endgame_points_average: float
     game_piece_average: float
     total_points_average: float
+    autonomous_level_4_coral_average: float = 0.0
+    autonomous_level_3_coral_average: float = 0.0
+    autonomous_level_2_coral_average: float = 0.0
+    autonomous_level_1_coral_average: float = 0.0
+    teleop_level_4_coral_average: float = 0.0
+    teleop_level_3_coral_average: float = 0.0
+    teleop_level_2_coral_average: float = 0.0
+    teleop_level_1_coral_average: float = 0.0
+    autonomous_net_average: float = 0.0
+    teleop_net_average: float = 0.0
+    autonomous_processor_average: float = 0.0
+    teleop_processor_average: float = 0.0
+    teleop_cycles_average: float = 0.0
     autonomous_points_z: float
     teleop_points_z: float
     endgame_points_z: float
     game_piece_z: float
     total_points_z: float
+    autonomous_level_4_coral_z: float = 0.0
+    autonomous_level_3_coral_z: float = 0.0
+    autonomous_level_2_coral_z: float = 0.0
+    autonomous_level_1_coral_z: float = 0.0
+    teleop_level_4_coral_z: float = 0.0
+    teleop_level_3_coral_z: float = 0.0
+    teleop_level_2_coral_z: float = 0.0
+    teleop_level_1_coral_z: float = 0.0
+    autonomous_net_z: float = 0.0
+    teleop_net_z: float = 0.0
+    autonomous_processor_z: float = 0.0
+    teleop_processor_z: float = 0.0
+    teleop_cycles_z: float = 0.0
 
 
 class DistributionStatistics(SQLModel):
@@ -275,33 +301,70 @@ def _build_team_summary_dataframe(
     working["game_piece_count"] = _calculate_game_piece_counts(
         working, config.game_piece_fields
     )
+    teleop_cycle_fields = [
+        field
+        for field in (
+            "tl4c",
+            "tl3c",
+            "tl2c",
+            "tl1c",
+            "tNet",
+            "tProcessor",
+        )
+        if field in working.columns
+    ]
+    if teleop_cycle_fields:
+        working["teleop_cycles"] = _calculate_game_piece_counts(
+            working, teleop_cycle_fields
+        )
     working["total_points"] = (
         working["autonomous_points"]
         + working["teleop_points"]
         + working["endgame_points"]
     )
 
+    aggregations = {
+        "matches_played": ("match_number", "count"),
+        "autonomous_points_average": ("autonomous_points", "mean"),
+        "teleop_points_average": ("teleop_points", "mean"),
+        "endgame_points_average": ("endgame_points", "mean"),
+        "game_piece_average": ("game_piece_count", "mean"),
+        "total_points_average": ("total_points", "mean"),
+    }
+
+    field_average_mapping = {
+        "al4c": "autonomous_level_4_coral_average",
+        "al3c": "autonomous_level_3_coral_average",
+        "al2c": "autonomous_level_2_coral_average",
+        "al1c": "autonomous_level_1_coral_average",
+        "tl4c": "teleop_level_4_coral_average",
+        "tl3c": "teleop_level_3_coral_average",
+        "tl2c": "teleop_level_2_coral_average",
+        "tl1c": "teleop_level_1_coral_average",
+        "aNet": "autonomous_net_average",
+        "tNet": "teleop_net_average",
+        "aProcessor": "autonomous_processor_average",
+        "tProcessor": "teleop_processor_average",
+    }
+
+    for field, alias in field_average_mapping.items():
+        if field in working.columns:
+            aggregations[alias] = (field, "mean")
+
+    if "teleop_cycles" in working.columns:
+        aggregations["teleop_cycles_average"] = ("teleop_cycles", "mean")
+
     summary = (
         working.groupby("team_number")
-        .agg(
-            matches_played=("match_number", "count"),
-            autonomous_points_average=("autonomous_points", "mean"),
-            teleop_points_average=("teleop_points", "mean"),
-            endgame_points_average=("endgame_points", "mean"),
-            game_piece_average=("game_piece_count", "mean"),
-            total_points_average=("total_points", "mean"),
-        )
+        .agg(**aggregations)
         .reset_index()
         .sort_values("team_number")
     )
 
-    for column in [
-        "autonomous_points_average",
-        "teleop_points_average",
-        "endgame_points_average",
-        "game_piece_average",
-        "total_points_average",
-    ]:
+    average_columns = [
+        column for column in summary.columns if column.endswith("_average")
+    ]
+    for column in average_columns:
         summary[column] = summary[column].fillna(0.0).round(2)
 
     summary["matches_played"] = summary["matches_played"].fillna(0).astype(int)
@@ -484,6 +547,19 @@ async def get_team_event_z_scores(
         "endgame_points_average",
         "game_piece_average",
         "total_points_average",
+        "autonomous_level_4_coral_average",
+        "autonomous_level_3_coral_average",
+        "autonomous_level_2_coral_average",
+        "autonomous_level_1_coral_average",
+        "teleop_level_4_coral_average",
+        "teleop_level_3_coral_average",
+        "teleop_level_2_coral_average",
+        "teleop_level_1_coral_average",
+        "autonomous_net_average",
+        "teleop_net_average",
+        "autonomous_processor_average",
+        "teleop_processor_average",
+        "teleop_cycles_average",
     ]
     summary_with_z, extremes = _append_z_scores(summary_df, stat_columns)
 

--- a/tests/test_team_event_summary.py
+++ b/tests/test_team_event_summary.py
@@ -247,3 +247,34 @@ def test_get_team_event_detailed_summary(summary_client):
     second_total = second["total_points"]
     for key in ("min", "lowerQuartile", "median", "upperQuartile", "max", "average"):
         assert second_total[key] == pytest.approx(41.0)
+
+
+def test_get_team_event_z_scores(summary_client):
+    response = summary_client.get("/analytics/event/teams/zScores")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    teams = payload["teams"]
+    assert len(teams) == 2
+
+    first, second = teams
+    assert first["team_number"] == 1111
+    assert second["team_number"] == 2222
+
+    assert first["autonomous_level_4_coral_average"] == pytest.approx(0.5)
+    assert first["teleop_cycles_average"] == pytest.approx(4.0)
+    assert second["teleop_cycles_average"] == pytest.approx(5.0)
+
+    assert first["autonomous_level_4_coral_z"] == pytest.approx(1.0)
+    assert second["autonomous_level_4_coral_z"] == pytest.approx(-1.0)
+    assert first["teleop_cycles_z"] == pytest.approx(-1.0)
+    assert second["teleop_cycles_z"] == pytest.approx(1.0)
+    assert first["autonomous_level_1_coral_z"] == pytest.approx(0.0)
+    assert second["autonomous_level_1_coral_z"] == pytest.approx(0.0)
+
+    extremes = payload["z_score_extremes"]
+    assert extremes["autonomous_level_4_coral_average"]["min"] == pytest.approx(-1.0)
+    assert extremes["autonomous_level_4_coral_average"]["max"] == pytest.approx(1.0)
+    assert extremes["teleop_cycles_average"]["min"] == pytest.approx(-1.0)
+    assert extremes["teleop_cycles_average"]["max"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- extend the z-score payload to include autonomous and teleop coral, net, processor, and cycle metrics
- compute the new per-team averages when building the summary dataframe and ensure teleop cycle counts are tracked
- cover the expanded response with a dedicated z-score API test

## Testing
- `pytest tests/test_team_event_summary.py` *(fails: missing optional dependency `aiosqlite` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf9d792788326ab82b467dae9da06