### PR TITLE
Adjust endgame success rate calculation

### DIFF
--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -8,9 +8,11 @@ from db.database import get_session
 from services.analytics.event_summary import (
     EventTeamZScoreResponse,
     TeamEventDetailedSummary,
+    TeamHeadToHeadStatistics,
     TeamEventSummary,
     TeamMatchHistory,
     get_team_event_detailed_summary,
+    get_team_event_head_to_head,
     get_team_event_match_history,
     get_team_event_summary,
     get_team_event_z_scores,
@@ -61,3 +63,14 @@ async def get_event_team_z_scores(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_team_event_z_scores(session, user)
+
+
+@router.get(
+    "/event/teams/headToHead",
+    response_model=List[TeamHeadToHeadStatistics],
+)
+async def get_event_team_head_to_head_statistics(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_team_event_head_to_head(session, user)

--- a/app/services/analytics/event_summary.py
+++ b/app/services/analytics/event_summary.py
@@ -188,6 +188,32 @@ class EventTeamZScoreResponse(SQLModel):
     z_score_extremes: Dict[str, StatisticZScoreExtremes]
 
 
+class HeadToHeadStatistic(SQLModel):
+    min: float = 0.0
+    max: float = 0.0
+    median: float = 0.0
+    average: float = 0.0
+    stdev: float = 0.0
+
+
+class TeamHeadToHeadStatistics(SQLModel):
+    team_number: int
+    matches_played: int
+    autonomous_coral: HeadToHeadStatistic
+    autonomous_net_algae: HeadToHeadStatistic
+    autonomous_processor_algae: HeadToHeadStatistic
+    autonomous_points: HeadToHeadStatistic
+    teleop_coral: HeadToHeadStatistic
+    teleop_game_pieces: HeadToHeadStatistic
+    teleop_points: HeadToHeadStatistic
+    teleop_net_algae: HeadToHeadStatistic
+    teleop_processor_algae: HeadToHeadStatistic
+    endgame_points: HeadToHeadStatistic
+    total_points: HeadToHeadStatistic
+    total_net_algae: HeadToHeadStatistic
+    endgame_success_rate: float = 0.0
+
+
 def _normalize_user_payload(user: object) -> Dict[str, object]:
     if isinstance(user, dict):
         return user
@@ -480,6 +506,134 @@ def _summarize_detailed_by_team(
     return summaries
 
 
+def _ensure_numeric_column(df: pd.DataFrame, column: str) -> pd.Series:
+    if column not in df.columns:
+        return pd.Series(0.0, index=df.index, dtype=float)
+    return pd.to_numeric(df[column], errors="coerce").fillna(0.0)
+
+
+def _calculate_head_to_head_metric(series: pd.Series) -> HeadToHeadStatistic:
+    if series.empty:
+        return HeadToHeadStatistic()
+
+    numeric_series = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric_series.empty:
+        return HeadToHeadStatistic()
+
+    return HeadToHeadStatistic(
+        min=_round_stat(numeric_series.min()),
+        max=_round_stat(numeric_series.max()),
+        median=_round_stat(numeric_series.median()),
+        average=_round_stat(numeric_series.mean()),
+        stdev=_round_stat(numeric_series.std(ddof=0)),
+    )
+
+
+def _calculate_endgame_success_rate(series: pd.Series) -> float:
+    if series.empty:
+        return 0.0
+
+    normalized = series.map(_normalize_endgame_value)
+    total = len(normalized)
+    if total == 0:
+        return 0.0
+
+    successes = normalized.isin({"SHALLOW", "DEEP"}).sum()
+    return _round_stat((successes / total) * 100.0)
+
+
+def _summarize_head_to_head_by_team(
+    df: pd.DataFrame, config: YearlyScoringConfig
+) -> List[TeamHeadToHeadStatistics]:
+    if df.empty:
+        return []
+
+    working = df.copy()
+    working["autonomous_points"] = _weighted_sum(working, config.auto_weights)
+    working["teleop_points"] = _weighted_sum(working, config.teleop_weights)
+    working["endgame_points"] = _endgame_points(working, config)
+
+    auto_coral_fields = ["al4c", "al3c", "al2c", "al1c"]
+    teleop_coral_fields = ["tl4c", "tl3c", "tl2c", "tl1c"]
+
+    working["autonomous_coral"] = _calculate_game_piece_counts(
+        working, auto_coral_fields
+    )
+    working["teleop_coral"] = _calculate_game_piece_counts(
+        working, teleop_coral_fields
+    )
+
+    working["autonomous_net_algae"] = _ensure_numeric_column(working, "aNet")
+    working["teleop_net_algae"] = _ensure_numeric_column(working, "tNet")
+    working["autonomous_processor_algae"] = _ensure_numeric_column(
+        working, "aProcessor"
+    )
+    working["teleop_processor_algae"] = _ensure_numeric_column(working, "tProcessor")
+
+    teleop_game_piece_fields = [
+        *teleop_coral_fields,
+        "tNet",
+        "tProcessor",
+    ]
+    working["teleop_game_pieces"] = _calculate_game_piece_counts(
+        working, teleop_game_piece_fields
+    )
+
+    working["total_points"] = (
+        working["autonomous_points"]
+        + working["teleop_points"]
+        + working["endgame_points"]
+    )
+    working["total_net_algae"] = (
+        working["autonomous_net_algae"] + working["teleop_net_algae"]
+    )
+
+    working["team_number"] = pd.to_numeric(
+        working["team_number"], errors="coerce"
+    ).fillna(0)
+    working["match_number"] = pd.to_numeric(
+        working["match_number"], errors="coerce"
+    ).fillna(0)
+
+    summaries: List[TeamHeadToHeadStatistics] = []
+    grouped = working.groupby("team_number")
+
+    metric_mapping = [
+        ("autonomous_coral", "autonomous_coral"),
+        ("autonomous_net_algae", "autonomous_net_algae"),
+        ("autonomous_processor_algae", "autonomous_processor_algae"),
+        ("autonomous_points", "autonomous_points"),
+        ("teleop_coral", "teleop_coral"),
+        ("teleop_game_pieces", "teleop_game_pieces"),
+        ("teleop_points", "teleop_points"),
+        ("teleop_net_algae", "teleop_net_algae"),
+        ("teleop_processor_algae", "teleop_processor_algae"),
+        ("endgame_points", "endgame_points"),
+        ("total_points", "total_points"),
+        ("total_net_algae", "total_net_algae"),
+    ]
+
+    for team_number, group in grouped:
+        metrics = {
+            alias: _calculate_head_to_head_metric(group[column])
+            for column, alias in metric_mapping
+        }
+
+        summaries.append(
+            TeamHeadToHeadStatistics(
+                team_number=int(team_number) if pd.notna(team_number) else 0,
+                matches_played=int(group["match_number"].count()),
+                endgame_success_rate=_calculate_endgame_success_rate(
+                    group["endgame"]
+                ),
+                **metrics,
+            )
+        )
+
+    summaries.sort(key=lambda entry: entry.team_number)
+    return summaries
+
+
 async def _load_event_dataframe(
     session: AsyncSession, user_payload: Dict[str, object]
 ) -> Tuple[pd.DataFrame, YearlyScoringConfig]:
@@ -661,5 +815,18 @@ async def get_team_event_match_history(
 
     histories.sort(key=lambda entry: entry.team_number)
     return histories
+
+
+async def get_team_event_head_to_head(
+    session: AsyncSession,
+    user: object,
+) -> List[TeamHeadToHeadStatistics]:
+    user_payload = _normalize_user_payload(user)
+    dataframe, scoring_config = await _load_event_dataframe(session, user_payload)
+
+    if dataframe.empty:
+        return []
+
+    return _summarize_head_to_head_by_team(dataframe, scoring_config)
 
 

--- a/tests/test_team_event_summary.py
+++ b/tests/test_team_event_summary.py
@@ -278,3 +278,110 @@ def test_get_team_event_z_scores(summary_client):
     assert extremes["autonomous_level_4_coral_average"]["max"] == pytest.approx(1.0)
     assert extremes["teleop_cycles_average"]["min"] == pytest.approx(-1.0)
     assert extremes["teleop_cycles_average"]["max"] == pytest.approx(1.0)
+
+
+def _assert_head_to_head_statistic(statistic, expected):
+    for key, value in expected.items():
+        assert statistic[key] == pytest.approx(value)
+
+
+def test_get_team_event_head_to_head(summary_client):
+    response = summary_client.get("/analytics/event/teams/headToHead")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+
+    first, second = payload
+
+    assert first["team_number"] == 1111
+    assert first["matches_played"] == 2
+    assert first["endgame_success_rate"] == pytest.approx(50.0)
+
+    _assert_head_to_head_statistic(
+        first["autonomous_coral"],
+        {"min": 1.0, "max": 2.0, "median": 1.5, "average": 1.5, "stdev": 0.5},
+    )
+    _assert_head_to_head_statistic(
+        first["autonomous_net_algae"],
+        {"min": 0.0, "max": 1.0, "median": 0.5, "average": 0.5, "stdev": 0.5},
+    )
+    _assert_head_to_head_statistic(
+        first["autonomous_processor_algae"],
+        {"min": 0.0, "max": 1.0, "median": 0.5, "average": 0.5, "stdev": 0.5},
+    )
+    _assert_head_to_head_statistic(
+        first["autonomous_points"],
+        {"min": 6.0, "max": 17.0, "median": 11.5, "average": 11.5, "stdev": 5.5},
+    )
+    _assert_head_to_head_statistic(
+        first["teleop_coral"],
+        {"min": 2.0, "max": 3.0, "median": 2.5, "average": 2.5, "stdev": 0.5},
+    )
+    _assert_head_to_head_statistic(
+        first["teleop_game_pieces"],
+        {"min": 4.0, "max": 4.0, "median": 4.0, "average": 4.0, "stdev": 0.0},
+    )
+    _assert_head_to_head_statistic(
+        first["teleop_points"],
+        {"min": 10.0, "max": 16.0, "median": 13.0, "average": 13.0, "stdev": 3.0},
+    )
+    _assert_head_to_head_statistic(
+        first["teleop_net_algae"],
+        {"min": 0.0, "max": 1.0, "median": 0.5, "average": 0.5, "stdev": 0.5},
+    )
+    _assert_head_to_head_statistic(
+        first["teleop_processor_algae"],
+        {"min": 1.0, "max": 1.0, "median": 1.0, "average": 1.0, "stdev": 0.0},
+    )
+    _assert_head_to_head_statistic(
+        first["endgame_points"],
+        {"min": 2.0, "max": 6.0, "median": 4.0, "average": 4.0, "stdev": 2.0},
+    )
+    _assert_head_to_head_statistic(
+        first["total_points"],
+        {"min": 18.0, "max": 39.0, "median": 28.5, "average": 28.5, "stdev": 10.5},
+    )
+    _assert_head_to_head_statistic(
+        first["total_net_algae"],
+        {"min": 0.0, "max": 2.0, "median": 1.0, "average": 1.0, "stdev": 1.0},
+    )
+
+    assert second["team_number"] == 2222
+    assert second["matches_played"] == 1
+    assert second["endgame_success_rate"] == pytest.approx(100.0)
+
+    for key in (
+        "autonomous_coral",
+        "autonomous_net_algae",
+        "autonomous_processor_algae",
+        "autonomous_points",
+        "teleop_coral",
+        "teleop_game_pieces",
+        "teleop_points",
+        "teleop_net_algae",
+        "teleop_processor_algae",
+        "endgame_points",
+        "total_points",
+        "total_net_algae",
+    ):
+        stat = second[key]
+        expected_value = {
+            "autonomous_coral": 2.0,
+            "autonomous_net_algae": 1.0,
+            "autonomous_processor_algae": 0.0,
+            "autonomous_points": 16.0,
+            "teleop_coral": 3.0,
+            "teleop_game_pieces": 5.0,
+            "teleop_points": 13.0,
+            "teleop_net_algae": 0.0,
+            "teleop_processor_algae": 2.0,
+            "endgame_points": 12.0,
+            "total_points": 41.0,
+            "total_net_algae": 1.0,
+        }[key]
+
+        for field in ("min", "max", "median", "average", "stdev"):
+            assert stat[field] == pytest.approx(expected_value if field != "stdev" else 0.0)


### PR DESCRIPTION
## Summary
- add head-to-head statistics models and service to compute per-team distributions
- expose /analytics/event/teams/headToHead endpoint to return the new analytics
- cover the endpoint with detailed expectations in the existing analytics test suite
- calculate endgame success rate as the share of SHALLOW/DEEP climbs

## Testing
- pytest tests/test_team_event_summary.py::test_get_team_event_head_to_head -q *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dc366075408326ba2c57e61c81565f