### PR TITLE
Add endpoint to retrieve event rankings

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -4,7 +4,7 @@ from auth.dependencies import get_current_user
 from db.database import get_session
 from typing import Any, Dict, List
 
-from models import Organization, FRCEvent
+from models import Organization, FRCEvent, EventRankings
 
 router = APIRouter(
     prefix="/event",
@@ -57,6 +57,15 @@ async def get_team_list(
 ) -> List[TeamRecordResponse]:
     event_code = await get_active_event_key_for_user(session, user)
     return await get_team_list_or_404(session, event_code)
+
+
+@router.get("/rankings")
+async def get_event_rankings(
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> List[EventRankings]:
+    event_code = await get_active_event_key_for_user(session, user)
+    return await get_event_rankings_or_404(session, event_code)
 
 
 @router.post("/getRankings")

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -230,6 +230,16 @@ async def get_team_list_or_404(session: AsyncSession, eventCode: str) -> List[Te
         location=tr.location
     ) for tr in teamRecordResult.scalars().all()]
 
+async def get_event_rankings_or_404(session: AsyncSession, eventCode: str) -> List[EventRankings]:
+    statement = select(EventRankings).where(
+        EventRankings.event_key == eventCode
+    ).order_by(EventRankings.rank)
+    result = await session.execute(statement)
+    rankings = result.scalars().all()
+    if not rankings:
+        raise HTTPException(status_code=404, detail="No rankings found for this event")
+    return rankings
+
 async def get_event_list_or_404(session: AsyncSession, year: int) -> List[EventResponse]:
     statement = select(FRCEvent).where(
         FRCEvent.year == year


### PR DESCRIPTION
## Summary
- add a service helper to load stored event rankings for an event
- expose a GET /event/rankings route that returns the rankings for the active event

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dc5935981c832687e9df1af39072a1