### PR TITLE
Include team names in event rankings response

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -4,7 +4,7 @@ from auth.dependencies import get_current_user
 from db.database import get_session
 from typing import Any, Dict, List
 
-from models import Organization, FRCEvent, EventRankings
+from models import Organization, FRCEvent
 
 router = APIRouter(
     prefix="/event",
@@ -63,7 +63,7 @@ async def get_team_list(
 async def get_event_rankings(
     session: AsyncSession = Depends(get_session),
     user=Depends(get_current_user),
-) -> List[EventRankings]:
+) -> List[EventRankingResponse]:
     event_code = await get_active_event_key_for_user(session, user)
     return await get_event_rankings_or_404(session, event_code)
 

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -1,7 +1,7 @@
 import os
 from enum import Enum
 from datetime import datetime
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 import httpx
@@ -64,6 +64,18 @@ class TeamRecordResponse(SQLModel):
     team_number: int
     team_name: str
     location: str
+
+
+class EventRankingResponse(SQLModel):
+    event_key: str
+    rank: int
+    team_number: int
+    team_name: Optional[str]
+    ranking_points: int
+    matches_played: int
+    ranking_tiebreaker_1: float
+    ranking_tiebreaker_2: float
+
 
 class EventResponse(SQLModel):
     event_key: str
@@ -230,15 +242,32 @@ async def get_team_list_or_404(session: AsyncSession, eventCode: str) -> List[Te
         location=tr.location
     ) for tr in teamRecordResult.scalars().all()]
 
-async def get_event_rankings_or_404(session: AsyncSession, eventCode: str) -> List[EventRankings]:
-    statement = select(EventRankings).where(
-        EventRankings.event_key == eventCode
-    ).order_by(EventRankings.rank)
+async def get_event_rankings_or_404(
+    session: AsyncSession, eventCode: str
+) -> List[EventRankingResponse]:
+    statement = (
+        select(EventRankings, TeamRecord.team_name)
+        .join(TeamRecord, TeamRecord.team_number == EventRankings.team_number, isouter=True)
+        .where(EventRankings.event_key == eventCode)
+        .order_by(EventRankings.rank)
+    )
     result = await session.execute(statement)
-    rankings = result.scalars().all()
+    rankings = result.all()
     if not rankings:
         raise HTTPException(status_code=404, detail="No rankings found for this event")
-    return rankings
+    return [
+        EventRankingResponse(
+            event_key=ranking.event_key,
+            rank=ranking.rank,
+            team_number=ranking.team_number,
+            team_name=team_name,
+            ranking_points=ranking.ranking_points,
+            matches_played=ranking.matches_played,
+            ranking_tiebreaker_1=ranking.ranking_tiebreaker_1,
+            ranking_tiebreaker_2=ranking.ranking_tiebreaker_2,
+        )
+        for ranking, team_name in rankings
+    ]
 
 async def get_event_list_or_404(session: AsyncSession, year: int) -> List[EventResponse]:
     statement = select(FRCEvent).where(


### PR DESCRIPTION
## Summary
- add an EventRankingResponse model that exposes the team name alongside the existing ranking fields
- return rankings by joining team records so each entry includes the team name when available
- update the rankings route to use the new response model

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dc5b239284832686fb745fed95ca68