### PR TITLE
Add picklist management endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,16 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routes import admin, analytics, event, organizationadmin, user, scout, team, season
+from routes import (
+    admin,
+    analytics,
+    event,
+    organizationadmin,
+    picklist,
+    scout,
+    season,
+    team,
+    user,
+)
 
 # Create FastAPI app
 app = FastAPI(title="Scouting App API")
@@ -22,6 +32,7 @@ app.include_router(analytics.router)
 app.include_router(user.router)
 app.include_router(event.router)
 app.include_router(organizationadmin.router)
+app.include_router(picklist.router)
 app.include_router(scout.router)
 app.include_router(team.router)
 app.include_router(season.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -18,3 +18,7 @@ from .team_at_event import TeamEvent
 from .user import User
 from .user_organization import UserOrganization, UserRole
 from .event_rankings import EventRankings
+from .picklist import PickList
+from .picklist_rank import PickListRank
+from .picklist_generator import PickListGenerator
+from .picklist_generator_2025 import PickListGenerator2025

--- a/app/models/picklist.py
+++ b/app/models/picklist.py
@@ -1,17 +1,18 @@
-from sqlmodel import SQLModel, Field, Relationship
+from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
-from .picklist_generator import PickListGenerator
-from datetime import datetime
+
+from sqlmodel import Field, SQLModel
 
 class PickList(SQLModel, table=True):
     __tablename__ = "picklist"
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     season: int = Field(foreign_key="season.id")
     organization_id: int = Field(foreign_key="organization.id")
-    event_key: int = Field(foreign_key="frcevent.event_key")
+    event_key: str = Field(foreign_key="frcevent.event_key")
     title: str = Field(default="Pick List")
     notes: Optional[str] = Field(default="")
     created: datetime = Field(default_factory=datetime.now)
     last_updated: datetime = Field(default_factory=datetime.now)
     favorited: bool = Field(default=False)
+

--- a/app/models/picklist_rank.py
+++ b/app/models/picklist_rank.py
@@ -1,11 +1,12 @@
-from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional
-from uuid import UUID, uuid4
-from .picklist_generator import PickListGenerator
-from datetime import datetime
+from uuid import UUID
 
-class PickList(SQLModel, table=True):
+from sqlmodel import Field, SQLModel
+
+
+class PickListRank(SQLModel, table=True):
     __tablename__ = "picklist_rank"
+
     picklist_id: UUID = Field(foreign_key="picklist.id", primary_key=True)
     rank: int = Field(primary_key=True)
     team_number: int = Field(foreign_key="teamrecord.team_number")

--- a/app/routes/picklist.py
+++ b/app/routes/picklist.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import ConfigDict
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from auth.dependencies import get_current_user
+from db.database import get_session
+from models import PickList, PickListRank
+from services.event import (
+    get_active_event_key_for_user,
+    get_event_or_404,
+    require_lead_or_admin_membership,
+)
+from services.picklist import (
+    fetch_picklist_generators,
+    fetch_picklists_for_event,
+    fetch_ranks_for_picklists,
+    get_picklist_generator_model_for_year,
+)
+
+
+router = APIRouter(
+    prefix="/picklists",
+    tags=["Pick Lists"],
+)
+
+
+class PickListRankPayload(SQLModel):
+    rank: int
+    team_number: int
+    notes: Optional[str] = None
+    dnp: bool = False
+
+
+class PickListCreateRequest(SQLModel):
+    title: str
+    notes: Optional[str] = None
+    favorited: Optional[bool] = False
+    ranks: List[PickListRankPayload]
+
+
+class PickListRankResponse(PickListRankPayload):
+    pass
+
+
+class PickListResponse(SQLModel):
+    id: UUID
+    season: int
+    organization_id: int
+    event_key: str
+    title: str
+    notes: Optional[str]
+    created: datetime
+    last_updated: datetime
+    favorited: bool
+    ranks: List[PickListRankResponse]
+
+
+class PickListGeneratorCreateRequest(SQLModel):
+    model_config = ConfigDict(extra="allow")
+
+    title: str
+    notes: str
+    favorited: bool
+
+
+@router.get("/generators")
+async def list_picklist_generators(
+    session: AsyncSession = Depends(get_session),
+    user: Dict[str, Any] = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    membership = await require_lead_or_admin_membership(session, user)
+    event_key = await get_active_event_key_for_user(session, user)
+    event = await get_event_or_404(session, event_key)
+
+    generators = await fetch_picklist_generators(
+        session,
+        membership.organization_id,
+        event.year,
+    )
+
+    return [generator.model_dump() for generator in generators]
+
+
+@router.get("")
+async def list_picklists(
+    session: AsyncSession = Depends(get_session),
+    user: Dict[str, Any] = Depends(get_current_user),
+) -> List[PickListResponse]:
+    membership = await require_lead_or_admin_membership(session, user)
+    event_key = await get_active_event_key_for_user(session, user)
+
+    picklists = await fetch_picklists_for_event(
+        session,
+        membership.organization_id,
+        event_key,
+    )
+
+    ranks_by_picklist = await fetch_ranks_for_picklists(
+        session,
+        [picklist.id for picklist in picklists],
+    )
+
+    responses: List[PickListResponse] = []
+    for picklist in picklists:
+        ranks = [
+            PickListRankResponse(**rank.model_dump(exclude={"picklist_id"}))
+            for rank in ranks_by_picklist.get(picklist.id, [])
+        ]
+        picklist_data = PickListResponse(
+            **picklist.model_dump(),
+            ranks=ranks,
+        )
+        responses.append(picklist_data)
+
+    return responses
+
+
+@router.post("")
+async def create_picklist(
+    request: PickListCreateRequest,
+    session: AsyncSession = Depends(get_session),
+    user: Dict[str, Any] = Depends(get_current_user),
+) -> PickListResponse:
+    membership = await require_lead_or_admin_membership(session, user)
+    event_key = await get_active_event_key_for_user(session, user)
+    event = await get_event_or_404(session, event_key)
+
+    seen_ranks = set()
+    for entry in request.ranks:
+        if entry.rank in seen_ranks:
+            raise HTTPException(status_code=400, detail="Duplicate rank value provided.")
+        seen_ranks.add(entry.rank)
+
+    timestamp = datetime.now()
+    picklist = PickList(
+        season=event.year,
+        organization_id=membership.organization_id,
+        event_key=event_key,
+        title=request.title,
+        notes=request.notes or "",
+        favorited=request.favorited if request.favorited is not None else False,
+        created=timestamp,
+        last_updated=timestamp,
+    )
+    session.add(picklist)
+    await session.flush()
+
+    for rank in request.ranks:
+        rank_entry = PickListRank(
+            picklist_id=picklist.id,
+            rank=rank.rank,
+            team_number=rank.team_number,
+            notes=rank.notes or "",
+            dnp=rank.dnp,
+        )
+        session.add(rank_entry)
+
+    await session.commit()
+    await session.refresh(picklist)
+
+    ranks = await fetch_ranks_for_picklists(session, [picklist.id])
+    rank_responses = [
+        PickListRankResponse(**rank.model_dump(exclude={"picklist_id"}))
+        for rank in ranks.get(picklist.id, [])
+    ]
+
+    return PickListResponse(
+        **picklist.model_dump(),
+        ranks=rank_responses,
+    )
+
+
+@router.post("/generators")
+async def create_picklist_generator(
+    request: PickListGeneratorCreateRequest,
+    session: AsyncSession = Depends(get_session),
+    user: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    membership = await require_lead_or_admin_membership(session, user)
+    event_key = await get_active_event_key_for_user(session, user)
+    event = await get_event_or_404(session, event_key)
+
+    generator_model = get_picklist_generator_model_for_year(event.year)
+
+    payload = request.model_dump()
+    base_fields = {
+        "title": payload.pop("title"),
+        "notes": payload.pop("notes"),
+        "favorited": payload.pop("favorited"),
+    }
+
+    generator = generator_model(
+        season=event.year,
+        organization_id=membership.organization_id,
+        **base_fields,
+        **payload,
+    )
+    session.add(generator)
+    await session.commit()
+    await session.refresh(generator)
+
+    return generator.model_dump()

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -393,6 +393,24 @@ async def _require_lead_or_admin_membership(
     return membership
 
 
+async def get_user_membership_or_404(
+    session: AsyncSession,
+    user: dict,
+) -> UserOrganization:
+    """Return the organization membership for the authenticated user."""
+
+    return await _get_user_membership(session, user)
+
+
+async def require_lead_or_admin_membership(
+    session: AsyncSession,
+    user: dict,
+) -> UserOrganization:
+    """Ensure the current user is an organization lead or admin."""
+
+    return await _require_lead_or_admin_membership(session, user)
+
+
 def _parse_team_number(team_key: str) -> int:
     if not team_key:
         raise HTTPException(status_code=400, detail="Ranking entry missing team key")

--- a/app/services/picklist.py
+++ b/app/services/picklist.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Sequence, Type
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from models import (
+    PickList,
+    PickListGenerator,
+    PickListGenerator2025,
+    PickListRank,
+)
+
+
+PICKLIST_GENERATOR_MODELS_BY_YEAR: Dict[int, Type[PickListGenerator]] = {
+    2025: PickListGenerator2025,
+}
+
+
+def get_picklist_generator_model_for_year(year: int) -> Type[PickListGenerator]:
+    try:
+        return PICKLIST_GENERATOR_MODELS_BY_YEAR[year]
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Pick list generators are not available for the {year} season.",
+        ) from exc
+
+
+async def fetch_picklist_generators(
+    session: AsyncSession,
+    organization_id: int,
+    season: int,
+) -> List[PickListGenerator]:
+    generator_model = get_picklist_generator_model_for_year(season)
+    statement = select(generator_model).where(
+        generator_model.organization_id == organization_id,
+        generator_model.season == season,
+    )
+    result = await session.execute(statement)
+    return list(result.scalars().all())
+
+
+async def fetch_picklists_for_event(
+    session: AsyncSession,
+    organization_id: int,
+    event_key: str,
+) -> List[PickList]:
+    statement = select(PickList).where(
+        PickList.organization_id == organization_id,
+        PickList.event_key == event_key,
+    ).order_by(PickList.favorited.desc(), PickList.created.desc())
+    result = await session.execute(statement)
+    return list(result.scalars().all())
+
+
+async def fetch_ranks_for_picklists(
+    session: AsyncSession,
+    picklist_ids: Sequence[UUID],
+) -> Dict[UUID, List[PickListRank]]:
+    if not picklist_ids:
+        return {}
+
+    statement = (
+        select(PickListRank)
+        .where(PickListRank.picklist_id.in_(picklist_ids))
+        .order_by(PickListRank.picklist_id, PickListRank.rank)
+    )
+    result = await session.execute(statement)
+
+    ranks_by_picklist: Dict[UUID, List[PickListRank]] = defaultdict(list)
+    for rank in result.scalars().all():
+        ranks_by_picklist[rank.picklist_id].append(rank)
+
+    return ranks_by_picklist


### PR DESCRIPTION
## Summary
- add pick list router with admin/lead-only endpoints for listing, creating, and managing pick lists tied to the active event
- implement season-aware pick list generator helpers and expose membership utilities for reuse
- register the pick list routes and surface related models in the package exports

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dd55551e008326a52b1abaf08ae35f