### PR TITLE
Update picklist season assignment to use season IDs

### DIFF
--- a/app/routes/picklist.py
+++ b/app/routes/picklist.py
@@ -23,6 +23,7 @@ from services.picklist import (
     fetch_ranks_for_picklists,
     get_picklist_generator_model_for_year,
 )
+from services.season import get_season_by_year_or_404
 
 
 router = APIRouter(
@@ -78,11 +79,13 @@ async def list_picklist_generators(
     membership = await require_lead_or_admin_membership(session, user)
     event_key = await get_active_event_key_for_user(session, user)
     event = await get_event_or_404(session, event_key)
+    season = await get_season_by_year_or_404(session, event.year)
 
     generators = await fetch_picklist_generators(
         session,
         membership.organization_id,
         event.year,
+        season.id,
     )
 
     return [generator.model_dump() for generator in generators]
@@ -131,6 +134,7 @@ async def create_picklist(
     membership = await require_lead_or_admin_membership(session, user)
     event_key = await get_active_event_key_for_user(session, user)
     event = await get_event_or_404(session, event_key)
+    season = await get_season_by_year_or_404(session, event.year)
 
     seen_ranks = set()
     for entry in request.ranks:
@@ -140,7 +144,7 @@ async def create_picklist(
 
     timestamp = datetime.now()
     picklist = PickList(
-        season=event.year,
+        season=season.id,
         organization_id=membership.organization_id,
         event_key=event_key,
         title=request.title,
@@ -186,6 +190,7 @@ async def create_picklist_generator(
     membership = await require_lead_or_admin_membership(session, user)
     event_key = await get_active_event_key_for_user(session, user)
     event = await get_event_or_404(session, event_key)
+    season = await get_season_by_year_or_404(session, event.year)
 
     generator_model = get_picklist_generator_model_for_year(event.year)
 
@@ -197,7 +202,7 @@ async def create_picklist_generator(
     }
 
     generator = generator_model(
-        season=event.year,
+        season=season.id,
         organization_id=membership.organization_id,
         **base_fields,
         **payload,

--- a/app/services/picklist.py
+++ b/app/services/picklist.py
@@ -34,12 +34,13 @@ def get_picklist_generator_model_for_year(year: int) -> Type[PickListGenerator]:
 async def fetch_picklist_generators(
     session: AsyncSession,
     organization_id: int,
-    season: int,
+    season_year: int,
+    season_id: int,
 ) -> List[PickListGenerator]:
-    generator_model = get_picklist_generator_model_for_year(season)
+    generator_model = get_picklist_generator_model_for_year(season_year)
     statement = select(generator_model).where(
         generator_model.organization_id == organization_id,
-        generator_model.season == season,
+        generator_model.season == season_id,
     )
     result = await session.execute(statement)
     return list(result.scalars().all())

--- a/app/services/season.py
+++ b/app/services/season.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -9,3 +10,12 @@ from models import Season
 async def get_seasons(session: AsyncSession) -> List[Season]:
     result = await session.exec(select(Season).order_by(Season.year))
     return result.all()
+
+
+async def get_season_by_year_or_404(session: AsyncSession, year: int) -> Season:
+    statement = select(Season).where(Season.year == year)
+    result = await session.execute(statement)
+    season = result.scalar_one_or_none()
+    if season is None:
+        raise HTTPException(status_code=404, detail=f"Season not found for year {year}")
+    return season


### PR DESCRIPTION
## Summary
- look up the active season record from the event year when handling picklists
- persist the season identifier on new picklists and picklist generators and query generators by that identifier

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68dd5f3e73748326b5d1d043a3b0d36f