### PR TITLE
Support generator-based picklist creation

### DIFF
--- a/app/routes/picklist.py
+++ b/app/routes/picklist.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import ConfigDict
-from sqlmodel import SQLModel, delete
+from sqlmodel import Field, SQLModel, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
@@ -21,6 +21,8 @@ from services.picklist import (
     fetch_picklist_generators,
     fetch_picklists_for_event,
     fetch_ranks_for_picklists,
+    generate_picklist_ranks_from_generator,
+    get_picklist_generator_by_id,
     get_picklist_generator_model_for_year,
 )
 from services.season import get_season_by_year_or_404
@@ -40,10 +42,13 @@ class PickListRankPayload(SQLModel):
 
 
 class PickListCreateRequest(SQLModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     title: str
     notes: Optional[str] = None
     favorited: Optional[bool] = False
-    ranks: List[PickListRankPayload]
+    generator_id: Optional[UUID] = Field(default=None, alias="generatorId")
+    ranks: List[PickListRankPayload] = Field(default_factory=list)
 
 
 class PickListRankResponse(PickListRankPayload):
@@ -161,11 +166,28 @@ async def create_picklist(
     event = await get_event_or_404(session, event_key)
     season = await get_season_by_year_or_404(session, event.year)
 
-    seen_ranks = set()
-    for entry in request.ranks:
-        if entry.rank in seen_ranks:
-            raise HTTPException(status_code=400, detail="Duplicate rank value provided.")
-        seen_ranks.add(entry.rank)
+    generated_rankings: List[int] = []
+    if request.generator_id is not None:
+        generator = await get_picklist_generator_by_id(
+            session=session,
+            generator_id=request.generator_id,
+            organization_id=membership.organization_id,
+            season_id=season.id,
+            season_year=event.year,
+        )
+        generated_rankings = await generate_picklist_ranks_from_generator(
+            session=session,
+            user=user,
+            generator=generator,
+        )
+    else:
+        seen_ranks = set()
+        for entry in request.ranks:
+            if entry.rank in seen_ranks:
+                raise HTTPException(
+                    status_code=400, detail="Duplicate rank value provided."
+                )
+            seen_ranks.add(entry.rank)
 
     timestamp = datetime.now()
     picklist = PickList(
@@ -181,15 +203,26 @@ async def create_picklist(
     session.add(picklist)
     await session.flush()
 
-    for rank in request.ranks:
-        rank_entry = PickListRank(
-            picklist_id=picklist.id,
-            rank=rank.rank,
-            team_number=rank.team_number,
-            notes=rank.notes or "",
-            dnp=rank.dnp,
-        )
-        session.add(rank_entry)
+    if generated_rankings:
+        for index, team_number in enumerate(generated_rankings, start=1):
+            rank_entry = PickListRank(
+                picklist_id=picklist.id,
+                rank=index,
+                team_number=team_number,
+                notes="",
+                dnp=False,
+            )
+            session.add(rank_entry)
+    else:
+        for rank in request.ranks:
+            rank_entry = PickListRank(
+                picklist_id=picklist.id,
+                rank=rank.rank,
+                team_number=rank.team_number,
+                notes=rank.notes or "",
+                dnp=rank.dnp,
+            )
+            session.add(rank_entry)
 
     await session.commit()
     await session.refresh(picklist)

--- a/app/services/analytics/event_summary.py
+++ b/app/services/analytics/event_summary.py
@@ -99,6 +99,13 @@ class TeamEventSummary(SQLModel):
     endgame_points_average: float
     game_piece_average: float
     total_points_average: float
+    autonomous_coral_average: float = 0.0
+    autonomous_algae_average: float = 0.0
+    teleop_coral_average: float = 0.0
+    teleop_algae_average: float = 0.0
+    total_coral_average: float = 0.0
+    total_algae_average: float = 0.0
+    total_game_pieces_average: float = 0.0
 
 
 class TeamEventZScoreSummary(SQLModel):
@@ -122,6 +129,13 @@ class TeamEventZScoreSummary(SQLModel):
     autonomous_processor_average: float = 0.0
     teleop_processor_average: float = 0.0
     teleop_cycles_average: float = 0.0
+    autonomous_coral_average: float = 0.0
+    autonomous_algae_average: float = 0.0
+    teleop_coral_average: float = 0.0
+    teleop_algae_average: float = 0.0
+    total_coral_average: float = 0.0
+    total_algae_average: float = 0.0
+    total_game_pieces_average: float = 0.0
     autonomous_points_z: float = 0.0
     teleop_points_z: float = 0.0
     endgame_points_z: float = 0.0
@@ -140,6 +154,13 @@ class TeamEventZScoreSummary(SQLModel):
     autonomous_processor_z: float = 0.0
     teleop_processor_z: float = 0.0
     teleop_cycles_z: float = 0.0
+    autonomous_coral_z: float = 0.0
+    autonomous_algae_z: float = 0.0
+    teleop_coral_z: float = 0.0
+    teleop_algae_z: float = 0.0
+    total_coral_z: float = 0.0
+    total_algae_z: float = 0.0
+    total_game_pieces_z: float = 0.0
 
 
 class DistributionStatistics(SQLModel):
@@ -327,6 +348,25 @@ def _build_team_summary_dataframe(
     working["game_piece_count"] = _calculate_game_piece_counts(
         working, config.game_piece_fields
     )
+    auto_coral_fields = ["al4c", "al3c", "al2c", "al1c"]
+    teleop_coral_fields = ["tl4c", "tl3c", "tl2c", "tl1c"]
+    working["autonomous_coral"] = _calculate_game_piece_counts(
+        working, auto_coral_fields
+    )
+    working["teleop_coral"] = _calculate_game_piece_counts(
+        working, teleop_coral_fields
+    )
+    working["autonomous_algae"] = (
+        _ensure_numeric_column(working, "aNet")
+        + _ensure_numeric_column(working, "aProcessor")
+    )
+    working["teleop_algae"] = (
+        _ensure_numeric_column(working, "tNet")
+        + _ensure_numeric_column(working, "tProcessor")
+    )
+    working["total_coral"] = working["autonomous_coral"] + working["teleop_coral"]
+    working["total_algae"] = working["autonomous_algae"] + working["teleop_algae"]
+    working["total_game_pieces"] = working["total_coral"] + working["total_algae"]
     teleop_cycle_fields = [
         field
         for field in (
@@ -356,6 +396,13 @@ def _build_team_summary_dataframe(
         "endgame_points_average": ("endgame_points", "mean"),
         "game_piece_average": ("game_piece_count", "mean"),
         "total_points_average": ("total_points", "mean"),
+        "autonomous_coral_average": ("autonomous_coral", "mean"),
+        "autonomous_algae_average": ("autonomous_algae", "mean"),
+        "teleop_coral_average": ("teleop_coral", "mean"),
+        "teleop_algae_average": ("teleop_algae", "mean"),
+        "total_coral_average": ("total_coral", "mean"),
+        "total_algae_average": ("total_algae", "mean"),
+        "total_game_pieces_average": ("total_game_pieces", "mean"),
     }
 
     field_average_mapping = {
@@ -704,6 +751,13 @@ async def get_team_event_z_scores(
         "endgame_points_average",
         "game_piece_average",
         "total_points_average",
+        "autonomous_coral_average",
+        "autonomous_algae_average",
+        "teleop_coral_average",
+        "teleop_algae_average",
+        "total_coral_average",
+        "total_algae_average",
+        "total_game_pieces_average",
         "autonomous_level_4_coral_average",
         "autonomous_level_3_coral_average",
         "autonomous_level_2_coral_average",

--- a/app/services/picklist.py
+++ b/app/services/picklist.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, List, Sequence, Type
+from typing import Any, Dict, List, Sequence, Type
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -14,10 +14,38 @@ from models import (
     PickListGenerator2025,
     PickListRank,
 )
+from services.analytics.event_summary import get_team_event_z_scores
 
 
 PICKLIST_GENERATOR_MODELS_BY_YEAR: Dict[int, Type[PickListGenerator]] = {
     2025: PickListGenerator2025,
+}
+
+
+GENERATOR_FIELD_TO_Z_SCORE: Dict[str, str] = {
+    "al4c": "autonomous_level_4_coral_z",
+    "al3c": "autonomous_level_3_coral_z",
+    "al2c": "autonomous_level_2_coral_z",
+    "al1c": "autonomous_level_1_coral_z",
+    "autonomous_coral": "autonomous_coral_z",
+    "autonomous_algae": "autonomous_algae_z",
+    "autonomous_points": "autonomous_points_z",
+    "tl4c": "teleop_level_4_coral_z",
+    "tl3c": "teleop_level_3_coral_z",
+    "tl2c": "teleop_level_2_coral_z",
+    "tl1c": "teleop_level_1_coral_z",
+    "teleop_coral": "teleop_coral_z",
+    "teleop_algae": "teleop_algae_z",
+    "teleop_points": "teleop_points_z",
+    "aNet": "autonomous_net_z",
+    "tNet": "teleop_net_z",
+    "aProcessor": "autonomous_processor_z",
+    "tProcessor": "teleop_processor_z",
+    "endgame_points": "endgame_points_z",
+    "total_coral": "total_coral_z",
+    "total_algae": "total_algae_z",
+    "total_game_pieces": "total_game_pieces_z",
+    "total_points": "total_points_z",
 }
 
 
@@ -78,3 +106,49 @@ async def fetch_ranks_for_picklists(
         ranks_by_picklist[rank.picklist_id].append(rank)
 
     return ranks_by_picklist
+
+
+async def get_picklist_generator_by_id(
+    session: AsyncSession,
+    generator_id: UUID,
+    organization_id: int,
+    season_id: int,
+    season_year: int,
+) -> PickListGenerator:
+    generator_model = get_picklist_generator_model_for_year(season_year)
+    generator = await session.get(generator_model, generator_id)
+
+    if generator is None:
+        raise HTTPException(status_code=404, detail="Pick list generator not found")
+
+    if generator.organization_id != organization_id or generator.season != season_id:
+        raise HTTPException(status_code=403, detail="Access to this generator is denied")
+
+    return generator
+
+
+async def generate_picklist_ranks_from_generator(
+    session: AsyncSession,
+    user: Dict[str, Any],
+    generator: PickListGenerator,
+) -> List[int]:
+    z_scores = await get_team_event_z_scores(session, user)
+    teams = z_scores.teams
+
+    if not teams:
+        return []
+
+    weighted_scores: List[tuple[int, float]] = []
+    for team in teams:
+        total_score = 0.0
+        for field, z_column in GENERATOR_FIELD_TO_Z_SCORE.items():
+            weight = getattr(generator, field, 0.0)
+            if not weight:
+                continue
+            z_value = getattr(team, z_column, 0.0)
+            total_score += weight * z_value
+
+        weighted_scores.append((team.team_number, total_score))
+
+    weighted_scores.sort(key=lambda item: (-item[1], item[0]))
+    return [team_number for team_number, _ in weighted_scores]

--- a/tests/test_picklist_generation.py
+++ b/tests/test_picklist_generation.py
@@ -1,0 +1,169 @@
+import asyncio
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependencies import get_current_user
+from app.main import app
+from app.models import (
+    Endgame2025,
+    FRCEvent,
+    MatchData2025,
+    Organization,
+    OrganizationEvent,
+    PickListGenerator2025,
+    Season,
+    TeamEvent,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_picklist_generation_data():
+    async with AsyncSessionLocal() as session:
+        season = Season(id=3, year=2025, name="REEFSCAPE")
+        event = FRCEvent(
+            event_key="2025picklist",
+            event_name="Picklist Event",
+            short_name="Picklist",
+            year=2025,
+            week=3,
+        )
+        organization = Organization(name="Picklist Org", team_number=2468)
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="picklist@example.com",
+            auth_provider="discord",
+            display_name="Picklist User",
+            logged_in_user_org=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+        teams = [
+            TeamRecord(teamNumber=3333, teamName="Team 3333"),
+            TeamRecord(teamNumber=4444, teamName="Team 4444"),
+        ]
+
+        session.add_all([season, event, organization, user, *teams])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.LEAD,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+
+        team_entries = [
+            TeamEvent(event_key=event.event_key, team_number=3333),
+            TeamEvent(event_key=event.event_key, team_number=4444),
+        ]
+
+        match_data = [
+            MatchData2025(
+                season=season.id,
+                team_number=3333,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al4c=1,
+                tl4c=1,
+                tNet=1,
+                endgame=Endgame2025.SHALLOW,
+            ),
+            MatchData2025(
+                season=season.id,
+                team_number=4444,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al4c=2,
+                tl4c=2,
+                tNet=1,
+                endgame=Endgame2025.DEEP,
+            ),
+        ]
+
+        generator = PickListGenerator2025(
+            season=season.id,
+            organization_id=organization.id,
+            title="Total Points Generator",
+            notes="",
+            favorited=False,
+            total_points=1.0,
+        )
+
+        session.add(organization_event)
+        session.add_all(team_entries)
+        session.add_all(match_data)
+        session.add(generator)
+        await session.commit()
+        await session.refresh(generator)
+
+        return user_id, membership.id, generator.id
+
+
+@pytest.fixture(scope="module")
+def prepared_picklist_generation_data(setup_database):
+    return asyncio.run(_prepare_picklist_generation_data())
+
+
+@pytest.fixture
+def picklist_client(prepared_picklist_generation_data):
+    user_id, membership_id, _ = prepared_picklist_generation_data
+
+    async def override_current_user():
+        return {
+            "id": str(user_id),
+            "displayName": "Picklist User",
+            "email": "picklist@example.com",
+            "user_org": membership_id,
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_create_picklist_with_generator(
+    picklist_client, prepared_picklist_generation_data
+):
+    _, _, generator_id = prepared_picklist_generation_data
+
+    response = picklist_client.post(
+        "/picklists",
+        json={"title": "Generated Picklist", "generatorId": str(generator_id)},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    ranks = payload["ranks"]
+    assert len(ranks) == 2
+    assert ranks[0]["rank"] == 1
+    assert ranks[0]["team_number"] == 4444
+    assert ranks[1]["team_number"] == 3333


### PR DESCRIPTION
## Summary
- allow POST /picklists to accept an optional generatorId and populate ranks from weighted Z-scores when provided
- extend the event summary pipeline with coral/algae aggregate averages and Z-scores required for generator weighting
- add regression coverage for generator-driven picklist creation

## Testing
- pytest tests/test_team_event_summary.py tests/test_picklist_generation.py *(fails: missing aiosqlite dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfb06df6083268a0e19039bb118ae