### PR TITLE
Add endpoints for uploading and listing team robot images

### DIFF
--- a/app/models/robot_event_image_link.py
+++ b/app/models/robot_event_image_link.py
@@ -1,13 +1,20 @@
-from sqlmodel import SQLModel, Field, Relationship
-from typing import Optional
+"""Database model for storing robot image links for a team at an event."""
+
+from __future__ import annotations
+
 from datetime import datetime
-import uuid
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlmodel import Field, SQLModel
 
 
 class RobotEventImageLink(SQLModel, table=True):
-    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True, index=True)
+    """A link to an image of a team's robot for a specific event."""
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
     team_number: int = Field(foreign_key="teamrecord.team_number")
     event_key: str = Field(foreign_key="frcevent.event_key")
     image_url: str = Field(max_length=2048)
     description: Optional[str] = Field(default=None, max_length=255)
-    uploaded_at: datetime = Field(default_factory=datetime.now())
+    uploaded_at: datetime = Field(default_factory=datetime.utcnow)

--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
@@ -6,6 +6,11 @@ from db.database import get_session
 from services.team import (
     get_match_data_for_team_at_active_event,
     get_team_or_404,
+)
+from services.team_media import (
+    RobotEventImageLinkResponse,
+    list_team_images,
+    upload_team_image,
 )
 
 router = APIRouter(
@@ -26,3 +31,38 @@ async def get_team_match_data(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_match_data_for_team_at_active_event(session, teamNumber, user)
+
+
+@router.post(
+    "/{teamNumber}/images",
+    response_model=RobotEventImageLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_team_image_endpoint(
+    teamNumber: int,
+    event_key: str = Form(...),
+    file: UploadFile = File(...),
+    description: str | None = Form(None),
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await upload_team_image(
+        session=session,
+        team_number=teamNumber,
+        event_key=event_key,
+        upload=file,
+        description=description,
+        user=user,
+    )
+
+
+@router.get(
+    "/{teamNumber}/images",
+    response_model=list[RobotEventImageLinkResponse],
+)
+async def list_team_images_endpoint(
+    teamNumber: int,
+    event_key: str = Query(...),
+    session: AsyncSession = Depends(get_session),
+):
+    return await list_team_images(session, teamNumber, event_key)

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -1,0 +1,173 @@
+"""Service layer for managing team robot media uploads."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Iterable, Optional
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException, UploadFile, status
+from pydantic import ConfigDict
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from models import RobotEventImageLink
+from services.aws import get_s3_client, get_team_images_bucket
+from services.event import get_event_or_404
+from services.team import get_team_or_404
+from sqlmodel import SQLModel
+
+ALLOWED_IMAGE_EXTENSIONS: Iterable[str] = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
+ALLOWED_IMAGE_CONTENT_TYPES: Iterable[str] = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/bmp",
+    "image/webp",
+}
+MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class RobotEventImageLinkResponse(SQLModel):
+    """Response DTO for robot event image link records."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    team_number: int
+    event_key: str
+    image_url: str
+    description: Optional[str]
+    uploaded_at: datetime
+
+
+async def _ensure_team_and_event(session: AsyncSession, team_number: int, event_key: str) -> None:
+    """Validate that the requested team and event exist."""
+
+    await get_team_or_404(session, team_number)
+    await get_event_or_404(session, event_key)
+
+
+def _validate_upload(upload: UploadFile) -> tuple[str, str]:
+    """Validate the uploaded file and return its suffix and content type."""
+
+    if not upload.filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file must include a filename.",
+        )
+
+    suffix = Path(upload.filename).suffix.lower()
+    if suffix not in ALLOWED_IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported image file type.",
+        )
+
+    content_type = upload.content_type or ""
+    if content_type.lower() not in ALLOWED_IMAGE_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported image content type.",
+        )
+
+    return suffix, content_type
+
+
+async def _read_upload(upload: UploadFile) -> BytesIO:
+    """Read the upload into memory enforcing a maximum size constraint."""
+
+    contents = await upload.read()
+    if not contents:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file was empty.",
+        )
+
+    if len(contents) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Uploaded file exceeds the 10MB limit.",
+        )
+
+    file_buffer = BytesIO(contents)
+    file_buffer.seek(0)
+    return file_buffer
+
+
+async def upload_team_image(
+    session: AsyncSession,
+    team_number: int,
+    event_key: str,
+    upload: UploadFile,
+    description: Optional[str],
+    user: dict,
+) -> RobotEventImageLinkResponse:
+    """Upload an image for a team's robot and persist its metadata."""
+
+    # Currently the user information is not persisted with the image link but is
+    # kept to allow future auditing or authorization checks.
+    _ = user
+
+    await _ensure_team_and_event(session, team_number, event_key)
+
+    suffix, content_type = _validate_upload(upload)
+    file_buffer = await _read_upload(upload)
+
+    object_key = f"{event_key}/{team_number}/{uuid4()}{suffix}"
+    bucket = get_team_images_bucket()
+    s3_client = get_s3_client()
+
+    extra_args = {"ACL": "public-read", "ContentType": content_type}
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        None,
+        lambda: s3_client.upload_fileobj(
+            file_buffer,
+            bucket,
+            object_key,
+            ExtraArgs=extra_args,
+        ),
+    )
+
+    image_url = f"https://{bucket}.s3.amazonaws.com/{object_key}"
+
+    record = RobotEventImageLink(
+        team_number=team_number,
+        event_key=event_key,
+        image_url=image_url,
+        description=description,
+        uploaded_at=datetime.utcnow(),
+    )
+
+    session.add(record)
+    await session.commit()
+    await session.refresh(record)
+
+    return RobotEventImageLinkResponse.model_validate(record)
+
+
+async def list_team_images(
+    session: AsyncSession,
+    team_number: int,
+    event_key: str,
+) -> list[RobotEventImageLinkResponse]:
+    """Return the stored robot images for a team at the given event."""
+
+    await _ensure_team_and_event(session, team_number, event_key)
+
+    statement = (
+        select(RobotEventImageLink)
+        .where(
+            RobotEventImageLink.team_number == team_number,
+            RobotEventImageLink.event_key == event_key,
+        )
+        .order_by(RobotEventImageLink.uploaded_at.desc())
+    )
+    result = await session.execute(statement)
+    records = result.scalars().all()
+    return [RobotEventImageLinkResponse.model_validate(record) for record in records]


### PR DESCRIPTION
## Summary
- add a refined RobotEventImageLink model for storing metadata about robot images
- implement a team media service that validates uploads, stores images on S3, and persists metadata
- expose POST/GET team routes for uploading and listing robot images tied to an event

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68decf2894a08326b75b5716600f3efb