### PR TITLE
Use active event for team image listing

### DIFF
--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
@@ -62,7 +62,7 @@ async def upload_team_image_endpoint(
 )
 async def list_team_images_endpoint(
     teamNumber: int,
-    event_key: str = Query(...),
+    user=Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-    return await list_team_images(session, teamNumber, event_key)
+    return await list_team_images(session, teamNumber, user)

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -16,7 +16,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from models import RobotEventImageLink
 from services.aws import get_s3_client, get_team_images_bucket
-from services.event import get_event_or_404
+from services.event import get_active_event_key_for_user, get_event_or_404
 from services.team import get_team_or_404
 from sqlmodel import SQLModel
 
@@ -154,9 +154,11 @@ async def upload_team_image(
 async def list_team_images(
     session: AsyncSession,
     team_number: int,
-    event_key: str,
+    user: dict,
 ) -> list[RobotEventImageLinkResponse]:
-    """Return the stored robot images for a team at the given event."""
+    """Return the stored robot images for a team at the user's active event."""
+
+    event_key = await get_active_event_key_for_user(session, user)
 
     await _ensure_team_and_event(session, team_number, event_key)
 


### PR DESCRIPTION
## Summary
- update the team image listing route to rely on the logged in user's active event
- resolve the team media service to look up the active event before querying images

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68ded3f4bd54832689cde8cd2580e712