### PR TITLE
Use active event for team image uploads

### DIFF
--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -40,7 +40,6 @@ async def get_team_match_data(
 )
 async def upload_team_image_endpoint(
     teamNumber: int,
-    event_key: str = Form(...),
     file: UploadFile = File(...),
     description: str | None = Form(None),
     user=Depends(get_current_user),
@@ -49,7 +48,6 @@ async def upload_team_image_endpoint(
     return await upload_team_image(
         session=session,
         team_number=teamNumber,
-        event_key=event_key,
         upload=file,
         description=description,
         user=user,

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -101,16 +101,13 @@ async def _read_upload(upload: UploadFile) -> BytesIO:
 async def upload_team_image(
     session: AsyncSession,
     team_number: int,
-    event_key: str,
     upload: UploadFile,
     description: Optional[str],
     user: dict,
 ) -> RobotEventImageLinkResponse:
     """Upload an image for a team's robot and persist its metadata."""
 
-    # Currently the user information is not persisted with the image link but is
-    # kept to allow future auditing or authorization checks.
-    _ = user
+    event_key = await get_active_event_key_for_user(session, user)
 
     await _ensure_team_and_event(session, team_number, event_key)
 


### PR DESCRIPTION
## Summary
- derive the team image upload event from the authenticated user's active event
- remove the event_key form field from the team image upload endpoint

## Testing
- pytest *(fails: missing aiosqlite dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded7f68f108326905c56669e8f96f4