### PR TITLE
Allow organization members to update pit records

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -887,7 +887,7 @@ async def update_pit_scout_record(
     statement = select(pit_model).where(
         pit_model.event_key == event_key,
         pit_model.team_number == team_number,
-        pit_model.user_id == user_id,
+        pit_model.organization_id == membership.organization_id,
     )
 
     result = await session.execute(statement)
@@ -896,9 +896,12 @@ async def update_pit_scout_record(
     if stored_record is None:
         raise HTTPException(status_code=404, detail="Pit scouting record not found for this team")
 
+    if stored_record.organization_id != membership.organization_id:
+        raise HTTPException(status_code=403, detail="Pit scouting record does not belong to this organization")
+
     stored_payload = _model_dump(stored_record)
     merged_payload = {**stored_payload, **payload}
-    merged_payload["user_id"] = user_id
+    merged_payload["user_id"] = stored_record.user_id
     merged_payload["organization_id"] = membership.organization_id
     merged_payload["notes"] = merged_payload.get("notes") or ""
 


### PR DESCRIPTION
## Summary
- allow pit scouting updates to target records owned by the caller's organization rather than only the original author
- preserve the original record author while validating organization ownership during updates

## Testing
- pytest tests/test_pit_routes.py *(fails: missing optional dependency `aiosqlite` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e03e4a45d083268d11ad6f8bb34669