### PR TITLE
Ensure pit scout responses include season-specific fields

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -136,11 +136,14 @@ async def update_tba_data(
     return await update_tba_match_data_for_pending_alliances(session, user)
 
 
-pit_scout_response_types: List[Type[PitScout]] = [PitScout]
+pit_scout_response_types: List[Type[PitScout]] = []
 
 for pit_model in PIT_SCOUT_MODELS_BY_YEAR.values():
     if pit_model not in pit_scout_response_types:
         pit_scout_response_types.append(pit_model)
+
+if PitScout not in pit_scout_response_types:
+    pit_scout_response_types.append(PitScout)
 
 PitScoutResponse = reduce(
     lambda accumulated, next_model: accumulated | next_model,


### PR DESCRIPTION
## Summary
- ensure pit scout response model prioritizes season-specific pit scouting schemas so 2025 data is serialized

## Testing
- pytest *(fails: missing dependency `aiosqlite` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04c689dd08326b107d2c2f0b59fba