### PR TITLE
Add endpoint for updating user info

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -1,8 +1,9 @@
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import SQLModel, select
+from sqlmodel import Field, SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
@@ -39,9 +40,52 @@ class UpdateUserOrganizationResponse(SQLModel):
     user_organization_id: int
 
 
+class UpdateUserInfoRequest(SQLModel):
+    display_name: str = Field(min_length=1)
+
+
 @router.get("/user/info")
 async def get_my_profile(user=Depends(get_current_user)):
     return user
+
+
+@router.patch("/user/info")
+async def update_my_profile(
+    update: UpdateUserInfoRequest,
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = user.get("id")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not authenticated")
+
+    if isinstance(user_id, str):
+        user_id = UUID(user_id)
+
+    db_user = await session.get(User, user_id)
+    if db_user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    display_name = update.display_name.strip()
+    if not display_name:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Display name cannot be empty",
+        )
+
+    db_user.display_name = display_name
+    db_user.updated_at = datetime.utcnow()
+
+    session.add(db_user)
+    await session.commit()
+    await session.refresh(db_user)
+
+    return {
+        "id": str(db_user.id),
+        "displayName": db_user.display_name,
+        "email": db_user.email,
+        "user_org": db_user.logged_in_user_org,
+    }
 
 
 @router.get(

--- a/tests/test_user_info.py
+++ b/tests/test_user_info.py
@@ -1,0 +1,87 @@
+import asyncio
+import os
+from datetime import datetime
+from uuid import uuid4
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependencies import get_current_user
+from app.main import app
+from app.models import User
+from tests.conftest import AsyncSessionLocal
+
+
+async def _create_user():
+    async with AsyncSessionLocal() as session:
+        user_id = uuid4()
+        email = "user@example.com"
+        user = User(
+            id=user_id,
+            email=email,
+            auth_provider="discord",
+            display_name="Original Name",
+            logged_in_user_org=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+        session.add(user)
+        await session.commit()
+
+        return {"user_id": user_id, "email": email}
+
+
+@pytest.fixture
+def user_client(setup_database):
+    user_data = asyncio.run(_create_user())
+
+    async def override_current_user():
+        return {
+            "id": str(user_data["user_id"]),
+            "displayName": "Original Name",
+            "email": user_data["email"],
+            "user_org": None,
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client, user_data
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_update_display_name(user_client):
+    client, data = user_client
+
+    response = client.patch("/user/info", json={"display_name": "Anthony"})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["displayName"] == "Anthony"
+    assert payload["id"] == str(data["user_id"])
+
+    async def _fetch_user():
+        async with AsyncSessionLocal() as session:
+            return await session.get(User, data["user_id"])
+
+    updated_user = asyncio.run(_fetch_user())
+    assert updated_user.display_name == "Anthony"
+
+
+def test_update_display_name_rejects_blank(user_client):
+    client, data = user_client
+
+    response = client.patch("/user/info", json={"display_name": "   "})
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Display name cannot be empty"
+
+    async def _fetch_user():
+        async with AsyncSessionLocal() as session:
+            return await session.get(User, data["user_id"])
+
+    updated_user = asyncio.run(_fetch_user())
+    assert updated_user.display_name == "Original Name"


### PR DESCRIPTION
## Summary
- add a PATCH `/user/info` endpoint so logged-in users can update their display name with basic validation and timestamp refreshes
- cover the new endpoint with tests that verify both successful updates and rejection of blank display names, including setting the SUPABASE_JWT_SECRET for imports
- restore `requirements.txt` to its original text form so the project no longer shows a binary diff for that file

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite'; package could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08ba932cc83268510f2f85e6f8aea