### PR TITLE
Add superscout field options endpoint

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
-from sqlmodel.ext.asyncio.session import AsyncSession
-from auth.dependencies import get_current_user
-from db.database import get_session
 from functools import reduce
 from typing import Any, Dict, List, Optional, Type
 from uuid import UUID
 
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from auth.dependencies import get_current_user
+from db.database import get_session
 
 from models import DataValidation, MatchData, PitScout, Season, SuperScoutData, ValidationStatus
 from services.event import MATCH_DATA_MODELS_BY_YEAR
@@ -28,6 +30,7 @@ from services.scout import (
     delete_pit_scout_record,
     get_already_scouted_matches,
     get_prescout_records,
+    get_superscout_field_options,
     get_superscout_records,
     get_data_validations_for_active_event,
     get_pit_scout_records,
@@ -41,6 +44,11 @@ from services.scout import (
     update_pit_scout_record,
     update_tba_match_data_for_pending_alliances,
 )
+
+
+class SuperScoutFieldOption(BaseModel):
+    key: str
+    label: str
 
 
 @router.get("/dataValidation", response_model=List[DataValidation])
@@ -251,6 +259,14 @@ async def list_superscout_records(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_superscout_records(session, user, team_number=team_number)
+
+
+@router.get("/superscout/fields", response_model=List[SuperScoutFieldOption])
+async def list_superscout_field_options(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_superscout_field_options(session, user)
 
 
 @router.post("/superscout", response_model=SuperScoutResponse, status_code=201)

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -61,6 +61,36 @@ SUPERSCOUT_MODELS_BY_YEAR: Dict[int, type[SuperScoutData]] = {
     2025: SuperScoutData2025,
 }
 
+SUPERSCOUT_BUTTON_FIELDS_BASE: List[Tuple[str, str]] = [
+    ("stopped_moving", "Stopped Moving"),
+    ("dead_lt_45_seconds", "Dead < 45 Seconds"),
+    ("dead_gt_45_seconds", "Dead > 45 Seconds"),
+    ("slow_drive", "Slow Drive"),
+    ("fast_drive", "Fast Drive"),
+    ("good_driving", "Good Driving"),
+    ("bad_driving", "Bad Driving"),
+    ("drops_game_pieces", "Drops Game Pieces"),
+    ("lots_of_fouls", "Lots of Fouls"),
+    ("tipped", "Tipped"),
+    ("didnt_move", "Did Not Move"),
+    ("broken", "Broken"),
+    ("no_show", "No Show"),
+    ("dnp", "DNP"),
+    ("played_defense", "Played Defense"),
+    ("received_defense", "Received Defense"),
+    ("yellow_card", "Yellow Card"),
+    ("red_card", "Red Card"),
+]
+
+SUPERSCOUT_BUTTON_FIELDS_BY_YEAR: Dict[int, List[Tuple[str, str]]] = {
+    2025: [
+        *SUPERSCOUT_BUTTON_FIELDS_BASE,
+        ("floor_algae", "Floor Algae"),
+        ("floor_coral", "Floor Coral"),
+        ("holds_both_pieces", "Holds Both Pieces"),
+    ],
+}
+
 TBA_BREAKDOWN_PARSERS_BY_YEAR: Dict[
     int, Callable[[Optional[Dict[str, Any]], Sequence[int]], Dict[str, Any]]
 ] = {}
@@ -783,6 +813,28 @@ async def get_superscout_records(
 
     result = await session.execute(statement)
     return result.scalars().all()
+
+
+async def get_superscout_field_options(
+    session: AsyncSession,
+    user: dict,
+) -> List[Dict[str, str]]:
+    user_payload = _normalize_user_payload(user)
+
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+
+    if SUPERSCOUT_MODELS_BY_YEAR.get(event.year) is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Superscouting is not available for this event",
+        )
+
+    field_options = SUPERSCOUT_BUTTON_FIELDS_BY_YEAR.get(
+        event.year, SUPERSCOUT_BUTTON_FIELDS_BASE
+    )
+
+    return [{"key": key, "label": label} for key, label in field_options]
 
 
 class PitScoutDeleteRequest(SQLModel):

--- a/tests/test_superscout_fields.py
+++ b/tests/test_superscout_fields.py
@@ -1,0 +1,117 @@
+import asyncio
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependencies import get_current_user
+from app.main import app
+from app.models import (
+    FRCEvent,
+    Organization,
+    OrganizationEvent,
+    Season,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_superscout_context():
+    async with AsyncSessionLocal() as session:
+        season = Season(id=7, year=2025, name="REEFSCAPE")
+        event = FRCEvent(
+            event_key="2025super",
+            event_name="Superscout Test Event",
+            short_name="SuperTest",
+            year=2025,
+            week=3,
+        )
+        organization = Organization(name="Super Org", team_number=2468)
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="super@example.com",
+            auth_provider="discord",
+            display_name="Super User",
+            logged_in_user_org=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+        session.add_all([season, event, organization, user])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        session.add(organization_event)
+        await session.commit()
+
+        return {
+            "user_id": user_id,
+            "membership_id": membership.id,
+        }
+
+
+@pytest.fixture(scope="module")
+def superscout_client(setup_database):
+    data = asyncio.run(_prepare_superscout_context())
+
+    async def override_current_user():
+        return {
+            "id": str(data["user_id"]),
+            "displayName": "Super User",
+            "email": "super@example.com",
+            "user_org": data["membership_id"],
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_get_superscout_field_options(superscout_client):
+    response = superscout_client.get("/scout/superscout/fields")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"key": "stopped_moving", "label": "Stopped Moving"},
+        {"key": "dead_lt_45_seconds", "label": "Dead < 45 Seconds"},
+        {"key": "dead_gt_45_seconds", "label": "Dead > 45 Seconds"},
+        {"key": "slow_drive", "label": "Slow Drive"},
+        {"key": "fast_drive", "label": "Fast Drive"},
+        {"key": "good_driving", "label": "Good Driving"},
+        {"key": "bad_driving", "label": "Bad Driving"},
+        {"key": "drops_game_pieces", "label": "Drops Game Pieces"},
+        {"key": "lots_of_fouls", "label": "Lots of Fouls"},
+        {"key": "tipped", "label": "Tipped"},
+        {"key": "didnt_move", "label": "Did Not Move"},
+        {"key": "broken", "label": "Broken"},
+        {"key": "no_show", "label": "No Show"},
+        {"key": "dnp", "label": "DNP"},
+        {"key": "played_defense", "label": "Played Defense"},
+        {"key": "received_defense", "label": "Received Defense"},
+        {"key": "yellow_card", "label": "Yellow Card"},
+        {"key": "red_card", "label": "Red Card"},
+        {"key": "floor_algae", "label": "Floor Algae"},
+        {"key": "floor_coral", "label": "Floor Coral"},
+        {"key": "holds_both_pieces", "label": "Holds Both Pieces"},
+    ]


### PR DESCRIPTION
## Summary
- add a GET /scout/superscout/fields endpoint that returns the available superscout button keys and labels for the active event
- centralize superscout button label definitions by season for reuse
- add an integration test covering the new endpoint response

## Testing
- pytest tests/test_superscout_fields.py *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e419752b5c8326a8b642adef7682a2