### PR TITLE
Auto-fill superscout submission metadata

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -271,7 +271,7 @@ async def list_superscout_field_options(
 
 @router.post("/superscout", response_model=SuperScoutResponse, status_code=201)
 async def create_superscout_entry(
-    superscout: SuperScoutData,
+    superscout: Dict[str, Any] = Body(...),
     user=Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1383,82 +1383,74 @@ async def submit_prescout_record(
 
 async def submit_superscout_record(
     session: AsyncSession,
-    superscout: SuperScoutData,
-    user: User,
+    superscout: Union[Dict[str, Any], SuperScoutData],
+    user: Any,
 ) -> SuperScoutData:
-    superscout_payload = _model_dump(superscout)
-    try:
-        base_superscout = cast(SuperScoutData, _model_validate(SuperScoutData, superscout_payload))
-    except ValidationError as exc:  # pragma: no cover - defensive guard
-        raise HTTPException(status_code=422, detail="Invalid superscout payload") from exc
+    payload = _coerce_payload(superscout)
+    user_payload = _normalize_user_payload(user)
 
-    user_id: Optional[UUID] = getattr(user, "id", None)
-    if user_id is None:
-        raise HTTPException(status_code=401, detail="User not authenticated")
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    incoming_event_key = payload.get("event_key")
+    if incoming_event_key is not None and incoming_event_key != event_key:
+        raise HTTPException(
+            status_code=400,
+            detail="Superscout event does not match the active event for this user",
+        )
+    payload["event_key"] = event_key
 
-    if isinstance(user_id, str):
-        try:
-            user_id = UUID(user_id)
-        except ValueError as exc:  # pragma: no cover - defensive programming
-            raise HTTPException(status_code=400, detail="Invalid user identifier") from exc
-
-    membership_id: Optional[Any] = getattr(user, "logged_in_user_org", None)
-    if membership_id is None:
-        raise HTTPException(status_code=404, detail="User is not logged into an organization")
-
-    if isinstance(membership_id, str):
-        try:
-            membership_id = int(membership_id)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid organization membership identifier",
-            ) from exc
-
-    membership = await session.get(UserOrganization, membership_id)
-    if membership is None:
-        raise HTTPException(status_code=404, detail="Organization membership not found")
+    membership = await _get_user_membership_or_404(session, user_payload)
+    user_id = await _normalize_user_id(user_payload)
 
     if membership.user_id != user_id:
         raise HTTPException(status_code=403, detail="User does not belong to this organization")
 
-    if base_superscout.organization_id != membership.organization_id:
+    incoming_user_id = _coerce_optional_uuid(payload.get("user_id"))
+    if incoming_user_id is not None and incoming_user_id != user_id:
         raise HTTPException(
             status_code=403,
-            detail="Superscout data does not belong to the active organization",
+            detail="Superscout data user does not match the authenticated user",
         )
+    payload["user_id"] = user_id
 
-    event = await get_event_or_404(session, base_superscout.event_key)
+    organization_id = membership.organization_id
+    incoming_org_id = payload.get("organization_id")
+    if incoming_org_id is not None:
+        try:
+            incoming_org_id_int = int(incoming_org_id)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid organization identifier for superscout data") from exc
 
-    season = await session.get(Season, base_superscout.season)
-    if season is None:
-        raise HTTPException(status_code=404, detail="Season not found for provided superscout data")
+        if incoming_org_id_int != organization_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Superscout data does not belong to the active organization",
+            )
+    payload["organization_id"] = organization_id
 
-    if event.year != season.year:
-        raise HTTPException(
-            status_code=400,
-            detail="Superscout data event does not match the expected season year",
-        )
+    event = await get_event_or_404(session, event_key)
 
-    superscout_model = SUPERSCOUT_MODELS_BY_YEAR.get(season.year)
+    season = await get_season_by_year_or_404(session, event.year)
+    incoming_season = payload.get("season")
+    if incoming_season is not None:
+        try:
+            incoming_season_id = int(incoming_season)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid season provided for superscout data") from exc
+
+        if incoming_season_id != season.id:
+            raise HTTPException(
+                status_code=400,
+                detail="Superscout season does not match the active event year",
+            )
+    payload["season"] = season.id
+
+    superscout_model = SUPERSCOUT_MODELS_BY_YEAR.get(event.year)
     if superscout_model is None:
         raise HTTPException(
             status_code=404,
             detail="Superscouting is not available for this season",
         )
 
-    superscout_user_id = getattr(base_superscout, "user_id", None)
-    if superscout_user_id and superscout_user_id != user_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Superscout data user does not match the authenticated user",
-        )
-
-    payload: Dict[str, Any] = {
-        **superscout_payload,
-        "user_id": user_id,
-        "organization_id": membership.organization_id,
-    }
     payload["notes"] = payload.get("notes") or ""
     payload.pop("timestamp", None)
 

--- a/tests/test_superscout_fields.py
+++ b/tests/test_superscout_fields.py
@@ -66,6 +66,9 @@ async def _prepare_superscout_context():
         return {
             "user_id": user_id,
             "membership_id": membership.id,
+            "organization_id": organization.id,
+            "event_key": event.event_key,
+            "season_id": season.id,
         }
 
 
@@ -84,6 +87,7 @@ def superscout_client(setup_database):
     app.dependency_overrides[get_current_user] = override_current_user
 
     with TestClient(app) as client:
+        client.test_context = data
         yield client
 
     app.dependency_overrides.pop(get_current_user, None)
@@ -115,3 +119,44 @@ def test_get_superscout_field_options(superscout_client):
         {"key": "floor_coral", "label": "Floor Coral"},
         {"key": "holds_both_pieces", "label": "Holds Both Pieces"},
     ]
+
+
+def test_create_superscout_record_auto_fields(superscout_client):
+    payload = {
+        "team_number": 111,
+        "match_number": 1,
+        "match_level": "qm",
+        "robot_overall": 4,
+        "timestamp": "2000-01-01T00:00:00Z",
+    }
+
+    response = superscout_client.post("/scout/superscout", json=payload)
+    assert response.status_code == 201
+
+    body = response.json()
+    context = superscout_client.test_context
+
+    assert body["event_key"] == context["event_key"]
+    assert body["season"] == context["season_id"]
+    assert body["user_id"] == str(context["user_id"])
+    assert body["organization_id"] == context["organization_id"]
+    assert body["notes"] == ""
+    assert body["team_number"] == payload["team_number"]
+    assert body["match_number"] == payload["match_number"]
+    assert body["match_level"] == payload["match_level"]
+    assert body["robot_overall"] == payload["robot_overall"]
+    assert body["timestamp"] != payload["timestamp"]
+
+
+def test_create_superscout_record_rejects_mismatched_event(superscout_client):
+    payload = {
+        "team_number": 111,
+        "match_number": 2,
+        "match_level": "qm",
+        "robot_overall": 5,
+        "event_key": "wrong_event",
+    }
+
+    response = superscout_client.post("/scout/superscout", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Superscout event does not match the active event for this user"


### PR DESCRIPTION
## Summary
- allow superscout submissions to omit user, event, season, organization, and timestamp metadata by deriving them from the logged-in user
- validate superscout payloads against the active organization and season before persisting
- extend superscout tests to cover automatic metadata population and mismatched event safeguards

## Testing
- pytest tests/test_superscout_fields.py *(fails: missing aiosqlite dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e438a6bda083268874ffe857857bde