### PR TITLE
Allow superscout optional defense and driver ratings

### DIFF
--- a/app/models/superscout_data.py
+++ b/app/models/superscout_data.py
@@ -44,6 +44,6 @@ class SuperScoutData(SQLModel):
     received_defense: bool = Field(default=False)
     yellow_card: bool = Field(default=False)
     red_card: bool = Field(default=False)
-    defense_rating: int = Field(nullable=True, ge=1, le=5)
-    driver_rating: int = Field(nullable=True, ge=1, le=5)
+    defense_rating: Optional[int] = Field(default=None, nullable=True, ge=1, le=5)
+    driver_rating: Optional[int] = Field(default=None, nullable=True, ge=1, le=5)
     robot_overall: int = Field(ge=1, le=5)


### PR DESCRIPTION
## Summary
- allow the superscout defense and driver ratings to be omitted by typing them as Optional
- default both fields to None so null payloads pass validation while keeping database nullability

## Testing
- pytest *(fails: missing aiosqlite dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43dcfd87883269462e845c19ea05c