### PR TITLE
Add superscouted match alliances endpoint

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -32,6 +32,7 @@ from services.scout import (
     get_prescout_records,
     get_superscout_field_options,
     get_superscout_records,
+    get_superscouted_match_alliances,
     get_data_validations_for_active_event,
     get_pit_scout_records,
     PitScoutDeleteRequest,
@@ -49,6 +50,14 @@ from services.scout import (
 class SuperScoutFieldOption(BaseModel):
     key: str
     label: str
+
+
+class SuperScoutMatchAllianceStatus(BaseModel):
+    eventCode: str
+    matchLevel: str
+    matchNumber: int
+    red: bool
+    blue: bool
 
 
 @router.get("/dataValidation", response_model=List[DataValidation])
@@ -259,6 +268,14 @@ async def list_superscout_records(
     session: AsyncSession = Depends(get_session),
 ):
     return await get_superscout_records(session, user, team_number=team_number)
+
+
+@router.get("/superscouted", response_model=List[SuperScoutMatchAllianceStatus])
+async def list_superscouted_alliances(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_superscouted_match_alliances(session, user)
 
 
 @router.get("/superscout/fields", response_model=List[SuperScoutFieldOption])

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -815,6 +815,85 @@ async def get_superscout_records(
     return result.scalars().all()
 
 
+async def get_superscouted_match_alliances(
+    session: AsyncSession,
+    user: dict,
+) -> List[Dict[str, Any]]:
+    user_payload = _normalize_user_payload(user)
+
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+
+    membership = await _get_user_membership_or_404(session, user_payload)
+
+    superscout_model = SUPERSCOUT_MODELS_BY_YEAR.get(event.year)
+    if superscout_model is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Superscouting is not available for this event",
+        )
+
+    schedule_statement = select(MatchSchedule).where(
+        MatchSchedule.event_key == event_key
+    )
+    schedule_result = await session.execute(schedule_statement)
+    match_schedules = schedule_result.scalars().all()
+
+    if not match_schedules:
+        return []
+
+    superscout_statement = select(superscout_model).where(
+        superscout_model.event_key == event_key,
+        superscout_model.organization_id == membership.organization_id,
+    )
+    superscout_result = await session.execute(superscout_statement)
+    superscout_records = superscout_result.scalars().all()
+
+    scouted_by_match: Dict[Tuple[str, int], Set[int]] = defaultdict(set)
+    for record in superscout_records:
+        scouted_by_match[(record.match_level, record.match_number)].add(
+            record.team_number
+        )
+
+    match_schedules.sort(key=lambda match: (match.match_level, match.match_number))
+
+    response: List[Dict[str, Any]] = []
+    for schedule in match_schedules:
+        match_key = (schedule.match_level, schedule.match_number)
+        scouted_teams = scouted_by_match.get(match_key, set())
+
+        red_teams = [
+            team
+            for team in (
+                schedule.red1_id,
+                schedule.red2_id,
+                schedule.red3_id,
+            )
+            if team is not None
+        ]
+        blue_teams = [
+            team
+            for team in (
+                schedule.blue1_id,
+                schedule.blue2_id,
+                schedule.blue3_id,
+            )
+            if team is not None
+        ]
+
+        response.append(
+            {
+                "eventCode": schedule.event_key,
+                "matchLevel": schedule.match_level,
+                "matchNumber": schedule.match_number,
+                "red": all(team in scouted_teams for team in red_teams),
+                "blue": all(team in scouted_teams for team in blue_teams),
+            }
+        )
+
+    return response
+
+
 async def get_superscout_field_options(
     session: AsyncSession,
     user: dict,

--- a/tests/test_superscout_fields.py
+++ b/tests/test_superscout_fields.py
@@ -9,9 +9,12 @@ from app.auth.dependencies import get_current_user
 from app.main import app
 from app.models import (
     FRCEvent,
+    MatchSchedule,
     Organization,
     OrganizationEvent,
     Season,
+    SuperScoutData2025,
+    TeamRecord,
     User,
     UserOrganization,
     UserRole,
@@ -160,3 +163,176 @@ def test_create_superscout_record_rejects_mismatched_event(superscout_client):
     response = superscout_client.post("/scout/superscout", json=payload)
     assert response.status_code == 400
     assert response.json()["detail"] == "Superscout event does not match the active event for this user"
+
+
+def test_get_superscouted_matches(superscout_client):
+    context = superscout_client.test_context
+
+    async def seed_superscout_data():
+        async with AsyncSessionLocal() as session:
+            teams = [
+                TeamRecord(teamNumber=number, teamName=f"Team {number}")
+                for number in (
+                    301,
+                    302,
+                    303,
+                    304,
+                    305,
+                    306,
+                    401,
+                    402,
+                    403,
+                    404,
+                    405,
+                    406,
+                )
+            ]
+            session.add_all(teams)
+            await session.commit()
+
+            schedules = [
+                MatchSchedule(
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    red1_id=301,
+                    red2_id=302,
+                    red3_id=303,
+                    blue1_id=304,
+                    blue2_id=305,
+                    blue3_id=306,
+                ),
+                MatchSchedule(
+                    event_key=context["event_key"],
+                    match_number=6,
+                    match_level="qm",
+                    red1_id=401,
+                    red2_id=402,
+                    red3_id=403,
+                    blue1_id=404,
+                    blue2_id=405,
+                    blue3_id=406,
+                ),
+            ]
+            session.add_all(schedules)
+            await session.commit()
+
+            superscout_entries = [
+                # Match 5: all alliances superscouted
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=301,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=302,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=303,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=304,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=305,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=306,
+                    event_key=context["event_key"],
+                    match_number=5,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                # Match 6: only red alliance superscouted
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=401,
+                    event_key=context["event_key"],
+                    match_number=6,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=402,
+                    event_key=context["event_key"],
+                    match_number=6,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+                SuperScoutData2025(
+                    season=context["season_id"],
+                    team_number=403,
+                    event_key=context["event_key"],
+                    match_number=6,
+                    match_level="qm",
+                    user_id=context["user_id"],
+                    organization_id=context["organization_id"],
+                    robot_overall=3,
+                ),
+            ]
+
+            session.add_all(superscout_entries)
+            await session.commit()
+
+    asyncio.run(seed_superscout_data())
+
+    response = superscout_client.get("/scout/superscouted")
+    assert response.status_code == 200
+
+    assert response.json() == [
+        {
+            "eventCode": context["event_key"],
+            "matchLevel": "qm",
+            "matchNumber": 5,
+            "red": True,
+            "blue": True,
+        },
+        {
+            "eventCode": context["event_key"],
+            "matchLevel": "qm",
+            "matchNumber": 6,
+            "red": True,
+            "blue": False,
+        },
+    ]


### PR DESCRIPTION
## Summary
- add a service helper and API route to expose superscouted alliances for the active event
- extend the superscout test module to seed match data and cover the new endpoint

## Testing
- pytest tests/test_superscout_fields.py *(fails: missing aiosqlite dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e474170e988326848f23cc68916aa8