### PR TITLE
Share scoring helpers between preview and prediction

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -27,6 +27,12 @@ from models import (
     EventRankings,
     StatboticsData,
 )
+from services.scoring import (
+    calculate_endgame_points,
+    extract_field_value,
+    resolve_endgame_points_mapping,
+    resolve_weight_mapping,
+)
 from services.season import get_season_by_year_or_404
 
 class MatchScheduleResponse(SQLModel):
@@ -351,64 +357,6 @@ def _initialize_count_lists(field_mapping: Tuple[Tuple[str, str], ...]) -> Dict[
     return {field: [] for field, _ in field_mapping}
 
 
-def _resolve_weight_mapping(
-    match_model: type[SQLModel],
-    attribute_name: str,
-    default: Dict[str, float],
-) -> Dict[str, float]:
-    mapping = getattr(match_model, attribute_name, None)
-    if isinstance(mapping, dict) and mapping:
-        resolved: Dict[str, float] = {}
-        for key, value in mapping.items():
-            try:
-                resolved[str(key)] = float(value)
-            except (TypeError, ValueError):
-                continue
-        if resolved:
-            return resolved
-    return {key: float(value) for key, value in default.items()}
-
-
-def _resolve_endgame_points_mapping(
-    match_model: type[SQLModel],
-) -> Dict[str, float]:
-    mapping = getattr(match_model, MATCH_MODEL_ENDGAME_POINTS_ATTR, None)
-    if isinstance(mapping, dict) and mapping:
-        resolved: Dict[str, float] = {}
-        for key, value in mapping.items():
-            try:
-                resolved[str(key).upper()] = float(value)
-            except (TypeError, ValueError):
-                continue
-        if resolved:
-            return resolved
-    return {key: float(value) for key, value in DEFAULT_ENDGAME_POINTS.items()}
-
-
-def _to_float(value: Any) -> float:
-    if value is None:
-        return 0.0
-    if isinstance(value, Enum):
-        value = value.value
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _extract_field_value(record: SQLModel, field_name: str) -> float:
-    return _to_float(getattr(record, field_name, 0))
-
-
-def _calculate_endgame_points(value: Any, mapping: Dict[str, float]) -> float:
-    if isinstance(value, Enum):
-        value = value.value
-    if value is None:
-        return 0.0
-    normalized = str(value).upper()
-    return float(mapping.get(normalized, 0.0))
-
-
 def _phase_metrics_from_lists(metric_lists: Dict[str, List[float]]) -> PhaseMetrics:
     return PhaseMetrics(
         level4=_calculate_metric_statistics(metric_lists["level4"]),
@@ -450,34 +398,34 @@ def _build_team_preview_from_records(
         teleop_total = 0.0
 
         for field, alias in AUTO_LEVEL_FIELDS:
-            count = _extract_field_value(record, field)
+            count = extract_field_value(record, field)
             auto_count_lists[field].append(count)
             auto_metric_lists[alias].append(count)
             points = count * auto_weights.get(field, 0.0)
             auto_total += points
 
         for field, alias in AUTO_ADDITIONAL_FIELDS:
-            count = _extract_field_value(record, field)
+            count = extract_field_value(record, field)
             auto_metric_lists[alias].append(count)
             auto_total += count * auto_weights.get(field, 0.0)
 
         auto_metric_lists["total_points"].append(auto_total)
 
         for field, alias in TELEOP_LEVEL_FIELDS:
-            count = _extract_field_value(record, field)
+            count = extract_field_value(record, field)
             teleop_count_lists[field].append(count)
             teleop_metric_lists[alias].append(count)
             points = count * teleop_weights.get(field, 0.0)
             teleop_total += points
 
         for field, alias in TELEOP_ADDITIONAL_FIELDS:
-            count = _extract_field_value(record, field)
+            count = extract_field_value(record, field)
             teleop_metric_lists[alias].append(count)
             teleop_total += count * teleop_weights.get(field, 0.0)
 
         teleop_metric_lists["total_points"].append(teleop_total)
 
-        endgame_value = _calculate_endgame_points(getattr(record, "endgame", None), endgame_points)
+        endgame_value = calculate_endgame_points(getattr(record, "endgame", None), endgame_points)
         endgame_values.append(endgame_value)
         total_match_points.append(auto_total + teleop_total + endgame_value)
 
@@ -629,9 +577,9 @@ async def get_match_preview(
             detail="Match data is not available for this event",
         )
 
-    auto_weights = _resolve_weight_mapping(match_model, MATCH_MODEL_AUTO_WEIGHTS_ATTR, DEFAULT_AUTO_WEIGHTS)
-    teleop_weights = _resolve_weight_mapping(match_model, MATCH_MODEL_TELEOP_WEIGHTS_ATTR, DEFAULT_TELEOP_WEIGHTS)
-    endgame_points = _resolve_endgame_points_mapping(match_model)
+    auto_weights = resolve_weight_mapping(match_model, MATCH_MODEL_AUTO_WEIGHTS_ATTR, DEFAULT_AUTO_WEIGHTS)
+    teleop_weights = resolve_weight_mapping(match_model, MATCH_MODEL_TELEOP_WEIGHTS_ATTR, DEFAULT_TELEOP_WEIGHTS)
+    endgame_points = resolve_endgame_points_mapping(match_model, MATCH_MODEL_ENDGAME_POINTS_ATTR, DEFAULT_ENDGAME_POINTS)
 
     red_teams = [match.red1_id, match.red2_id, match.red3_id]
     blue_teams = [match.blue1_id, match.blue2_id, match.blue3_id]

--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -17,9 +17,21 @@ from models import (
     UserOrganization,
 )
 from services.event import (
+    DEFAULT_AUTO_WEIGHTS,
+    DEFAULT_ENDGAME_POINTS,
+    DEFAULT_TELEOP_WEIGHTS,
     MATCH_DATA_MODELS_BY_YEAR,
+    MATCH_MODEL_AUTO_WEIGHTS_ATTR,
+    MATCH_MODEL_ENDGAME_POINTS_ATTR,
+    MATCH_MODEL_TELEOP_WEIGHTS_ATTR,
     get_active_event_key_for_user,
     get_event_or_404,
+)
+from services.scoring import (
+    calculate_endgame_points,
+    calculate_phase_points,
+    resolve_endgame_points_mapping,
+    resolve_weight_mapping,
 )
 
 RecordType = TypeVar("RecordType", bound=MatchData)
@@ -40,6 +52,21 @@ MATCH_DATA_FIELDS_TO_EXCLUDE = {
     "timestamp",
     "notes",
 }
+def _apply_calculated_fields(
+    records: Sequence[MatchData],
+    auto_weights: Dict[str, float],
+    teleop_weights: Dict[str, float],
+    endgame_points: Dict[str, float],
+) -> None:
+    if not records:
+        return
+
+    for record in records:
+        record.autonomous_points = calculate_phase_points(record, auto_weights)
+        record.teleop_points = calculate_phase_points(record, teleop_weights)
+        record.endgame_points = calculate_endgame_points(
+            getattr(record, "endgame", None), endgame_points
+        )
 
 
 def _normalize_user_payload(user: Any) -> Dict[str, Any]:
@@ -132,20 +159,51 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
     limit = 10
 
     if match_model is not None:
+        auto_weights = resolve_weight_mapping(
+            match_model, MATCH_MODEL_AUTO_WEIGHTS_ATTR, DEFAULT_AUTO_WEIGHTS
+        )
+        teleop_weights = resolve_weight_mapping(
+            match_model, MATCH_MODEL_TELEOP_WEIGHTS_ATTR, DEFAULT_TELEOP_WEIGHTS
+        )
+        endgame_points = resolve_endgame_points_mapping(
+            match_model, MATCH_MODEL_ENDGAME_POINTS_ATTR, DEFAULT_ENDGAME_POINTS
+        )
+
         scouted_records = await _fetch_match_records(
             session, match_model, event_key, membership.organization_id
         )
-        ordered_records.extend(
-            _collect_latest_matches(scouted_records, seen_matches, limit)
+        latest_matches = _collect_latest_matches(
+            scouted_records, seen_matches, limit
         )
+        _apply_calculated_fields(
+            latest_matches, auto_weights, teleop_weights, endgame_points
+        )
+        ordered_records.extend(latest_matches)
 
     if len(seen_matches) < limit and prescout_model is not None:
+        prescout_auto_weights = resolve_weight_mapping(
+            prescout_model, MATCH_MODEL_AUTO_WEIGHTS_ATTR, DEFAULT_AUTO_WEIGHTS
+        )
+        prescout_teleop_weights = resolve_weight_mapping(
+            prescout_model, MATCH_MODEL_TELEOP_WEIGHTS_ATTR, DEFAULT_TELEOP_WEIGHTS
+        )
+        prescout_endgame_points = resolve_endgame_points_mapping(
+            prescout_model, MATCH_MODEL_ENDGAME_POINTS_ATTR, DEFAULT_ENDGAME_POINTS
+        )
+
         prescout_records = await _fetch_match_records(
             session, prescout_model, event_key, membership.organization_id
         )
-        ordered_records.extend(
-            _collect_latest_matches(prescout_records, seen_matches, limit)
+        latest_prescout = _collect_latest_matches(
+            prescout_records, seen_matches, limit
         )
+        _apply_calculated_fields(
+            latest_prescout,
+            prescout_auto_weights,
+            prescout_teleop_weights,
+            prescout_endgame_points,
+        )
+        ordered_records.extend(latest_prescout)
 
     return ordered_records
 

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -1,0 +1,78 @@
+"""Utility functions for working with match scoring data."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict
+
+
+def resolve_weight_mapping(
+    match_model: type[Any],
+    attribute_name: str,
+    default: Dict[str, float],
+) -> Dict[str, float]:
+    """Return a mapping of field names to weights for the given model."""
+
+    mapping = getattr(match_model, attribute_name, None)
+    if isinstance(mapping, dict) and mapping:
+        resolved: Dict[str, float] = {}
+        for key, value in mapping.items():
+            try:
+                resolved[str(key)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        if resolved:
+            return resolved
+    return {key: float(value) for key, value in default.items()}
+
+
+def resolve_endgame_points_mapping(
+    match_model: type[Any],
+    attribute_name: str,
+    default: Dict[str, float],
+) -> Dict[str, float]:
+    """Return the endgame point mapping for the given model."""
+
+    mapping = getattr(match_model, attribute_name, None)
+    if isinstance(mapping, dict) and mapping:
+        resolved: Dict[str, float] = {}
+        for key, value in mapping.items():
+            try:
+                resolved[str(key).upper()] = float(value)
+            except (TypeError, ValueError):
+                continue
+        if resolved:
+            return resolved
+    return {key: float(value) for key, value in default.items()}
+
+
+def to_float(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, Enum):
+        value = value.value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def calculate_phase_points(record: Any, weights: Dict[str, float]) -> float:
+    return sum(to_float(getattr(record, field, 0)) * float(weight) for field, weight in weights.items())
+
+
+def calculate_endgame_points(value: Any, mapping: Dict[str, float]) -> float:
+    if isinstance(value, Enum):
+        value = value.value
+    if value is None:
+        return 0.0
+
+    normalized = str(value).upper()
+    try:
+        return float(mapping.get(normalized, mapping.get(str(value), 0.0)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def extract_field_value(record: Any, field_name: str) -> float:
+    return to_float(getattr(record, field_name, 0))

--- a/tests/test_match_prediction.py
+++ b/tests/test_match_prediction.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from app.models import (
+    Endgame2025,
+    FRCEvent,
+    MatchData2025,
+    Organization,
+    OrganizationEvent,
+    Season,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from app.services.match_prediction import calculate_weighted_match_statistics
+from tests.conftest import AsyncSessionLocal
+
+
+@pytest.mark.asyncio
+async def test_weighted_statistics_include_calculated_point_fields(setup_database):
+    async with AsyncSessionLocal() as session:
+        season = Season(id=99, year=2025, name="REEFSCAPE Test")
+        event = FRCEvent(
+            event_key="2025prediction",
+            event_name="Prediction Event",
+            short_name="Predict",
+            year=2025,
+            week=1,
+        )
+        organization = Organization(name="Prediction Org", team_number=1234)
+        now = datetime.utcnow()
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="predict@example.com",
+            auth_provider="discord",
+            display_name="Predict User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+        team_record = TeamRecord(team_number=1234, team_name="Team 1234")
+
+        session.add_all([season, event, organization, user, team_record])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        session.add(organization_event)
+
+        matches = [
+            MatchData2025(
+                season=season.id,
+                team_number=team_record.team_number,
+                event_key=event.event_key,
+                match_number=2,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al3c=2,
+                aProcessor=1,
+                tl2c=1,
+                tNet=1,
+                endgame=Endgame2025.PARK,
+            ),
+            MatchData2025(
+                season=season.id,
+                team_number=team_record.team_number,
+                event_key=event.event_key,
+                match_number=3,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                al4c=1,
+                aNet=1,
+                tl3c=2,
+                tProcessor=1,
+                endgame=Endgame2025.SHALLOW,
+            ),
+        ]
+        session.add_all(matches)
+        await session.commit()
+
+        user_payload = {"id": str(user_id), "user_org": membership.id}
+
+        result = await calculate_weighted_match_statistics(session, user_payload)
+
+        assert result["sample_size"] == 2
+        statistics = result["statistics"]
+
+        assert "autonomous_points" in statistics
+        assert "teleop_points" in statistics
+        assert "endgame_points" in statistics
+
+        auto_average = statistics["autonomous_points"]["weighted_average"]
+        teleop_average = statistics["teleop_points"]["weighted_average"]
+        endgame_average = statistics["endgame_points"]["weighted_average"]
+
+        assert auto_average == pytest.approx(12.5)
+        assert teleop_average == pytest.approx(8.5)
+        assert endgame_average == pytest.approx(4.0)
+
+        auto_std = statistics["autonomous_points"]["weighted_standard_deviation"]
+        teleop_std = statistics["teleop_points"]["weighted_standard_deviation"]
+        endgame_std = statistics["endgame_points"]["weighted_standard_deviation"]
+
+        assert auto_std == pytest.approx(1.5)
+        assert teleop_std == pytest.approx(1.5)
+        assert endgame_std == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- factor shared scoring utility helpers so match preview and prediction use identical point weights
- update the match prediction service to rely on the shared helpers when calculating autonomous, teleop, and endgame totals
- switch the match preview service to use the shared helpers to keep the scoring logic consistent in both endpoints

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68e53dcdffcc8326854c988bfcd06de6