### PR TITLE
Model climb scoring with Bernoulli sampling

### DIFF
--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -239,6 +239,39 @@ async def _get_team_statistics(
 
     total_mean, total_std = _compute_weighted_statistics(records, statbotics_total)
 
+    def _extract_climb_probability(record: MatchData) -> float | None:
+        raw_probability = getattr(record, "climb_rate", None)
+        if raw_probability is None:
+            raw_probability = getattr(record, "climb_success", None)
+
+        if raw_probability is None:
+            endgame_value = getattr(record, "endgame", None)
+            if endgame_value is not None:
+                normalized = str(getattr(endgame_value, "value", endgame_value)).upper()
+                raw_probability = 1.0 if normalized == "DEEP" else 0.0
+
+        if raw_probability is None:
+            endgame_points_value = getattr(record, "endgame_points", None)
+            if endgame_points_value is not None:
+                try:
+                    raw_probability = 1.0 if float(endgame_points_value) >= 12.0 else 0.0
+                except (TypeError, ValueError):
+                    return None
+
+        if raw_probability is None:
+            return None
+
+        try:
+            probability = float(raw_probability)
+        except (TypeError, ValueError):
+            return None
+
+        if probability < 0.0:
+            return 0.0
+        if probability > 1.0:
+            return 1.0
+        return probability
+
     auto_coral_mean, auto_coral_std = _compute_weighted_metric(
         records, lambda record: _sum_record_fields(record, ("al4c", "al3c", "al2c", "al1c"))
     )
@@ -266,12 +299,23 @@ async def _get_team_statistics(
         records, lambda record: getattr(record, "endgame_points", 0.0)
     )
 
+    climb_rate_mean, climb_rate_std = _compute_weighted_metric(
+        records, _extract_climb_probability
+    )
+
+    base_total_mean = total_mean - (climb_rate_mean * 12.0)
+    climb_variance = 144.0 * climb_rate_mean * (1.0 - climb_rate_mean)
+    base_total_variance = max(0.0, total_std**2 - climb_variance)
+    base_total_std = sqrt(base_total_variance)
+
     return {
         "total": (total_mean, total_std),
+        "total_without_climb": (base_total_mean, base_total_std),
         "auto_coral": (auto_coral_mean, auto_coral_std),
         "total_coral": (total_coral_mean, total_coral_std),
         "processor": (processor_mean, processor_std),
         "endgame": (endgame_mean, endgame_std),
+        "climb_rate": (climb_rate_mean, climb_rate_std),
     }
 
 def _apply_calculated_fields(
@@ -302,9 +346,13 @@ def _apply_calculated_fields(
         record.autonomous_points = autonomous_points
         record.teleop_points = teleop_points
         record.endgame_points = endgame_points_total
+        climb_points = 12.0 if endgame_points_total >= 12.0 else 0.0
+        record.climb_points = climb_points
+        record.climb_success = 1.0 if climb_points >= 12.0 else 0.0
         record.total_points = (
             autonomous_points + teleop_points + endgame_points_total
         )
+        record.total_points_without_climb = record.total_points - climb_points
 
 
 def _normalize_user_payload(user: Any) -> Dict[str, Any]:
@@ -675,17 +723,39 @@ async def simulate_match_prediction(
                 samples += team_samples
             return samples
 
-        red_total_samples = _generate_alliance_samples(red_stats, "total")
-        blue_total_samples = _generate_alliance_samples(blue_stats, "total")
+        red_total_samples = _generate_alliance_samples(red_stats, "total_without_climb")
+        blue_total_samples = _generate_alliance_samples(blue_stats, "total_without_climb")
+
+        def _sample_alliance_climb(
+            team_statistics: Sequence[Dict[str, Tuple[float, float]]]
+        ) -> Tuple[np.ndarray, np.ndarray]:
+            climb_points = np.zeros(n_samples)
+            any_climb = np.zeros(n_samples, dtype=bool)
+
+            for stats in team_statistics:
+                climb_rate = float(stats.get("climb_rate", (0.0, 0.0))[0])
+                if climb_rate <= 0.0:
+                    continue
+                probability = min(max(climb_rate, 0.0), 1.0)
+                team_success = rng.random(n_samples) < probability
+                if not np.any(team_success):
+                    continue
+                climb_points += team_success.astype(float) * 12.0
+                any_climb = np.logical_or(any_climb, team_success)
+
+            return climb_points, any_climb
+
+        red_climb_points, red_any_climb = _sample_alliance_climb(red_stats)
+        blue_climb_points, blue_any_climb = _sample_alliance_climb(blue_stats)
+
+        red_total_samples += red_climb_points
+        blue_total_samples += blue_climb_points
 
         red_win_pct = float(np.mean(red_total_samples > blue_total_samples))
         blue_win_pct = 1.0 - red_win_pct
 
         red_auto_coral_samples = _generate_alliance_samples(red_stats, "auto_coral")
         blue_auto_coral_samples = _generate_alliance_samples(blue_stats, "auto_coral")
-
-        red_endgame_samples = _generate_alliance_samples(red_stats, "endgame")
-        blue_endgame_samples = _generate_alliance_samples(blue_stats, "endgame")
 
         red_total_coral_samples = _generate_alliance_samples(red_stats, "total_coral")
         blue_total_coral_samples = _generate_alliance_samples(blue_stats, "total_coral")
@@ -696,8 +766,8 @@ async def simulate_match_prediction(
         red_auto_rp = float(np.mean(red_auto_coral_samples >= 1.0))
         blue_auto_rp = float(np.mean(blue_auto_coral_samples >= 1.0))
 
-        red_endgame_rp = float(np.mean(red_endgame_samples >= 12.0))
-        blue_endgame_rp = float(np.mean(blue_endgame_samples >= 12.0))
+        red_endgame_rp = float(np.mean(red_any_climb))
+        blue_endgame_rp = float(np.mean(blue_any_climb))
 
         red_w_coral_rp = float(np.mean(red_total_coral_samples >= 27.0))
         blue_w_coral_rp = float(np.mean(blue_total_coral_samples >= 27.0))

--- a/tests/test_match_prediction.py
+++ b/tests/test_match_prediction.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 from uuid import uuid4
 
+import numpy as np
 import pytest
 
 from app.models import (
     Endgame2025,
     FRCEvent,
     MatchData2025,
+    MatchSchedule,
     Organization,
     OrganizationEvent,
     Season,
@@ -19,6 +21,7 @@ from app.models import (
 from app.services.match_prediction import (
     calculate_weighted_match_statistics,
     retrieve_prediction_data,
+    simulate_match_prediction,
 )
 from tests.conftest import AsyncSessionLocal
 
@@ -331,3 +334,101 @@ async def test_missing_statbotics_data_triggers_update(monkeypatch, setup_databa
         assert teleop_average == pytest.approx(360 / 23)
         assert endgame_average == pytest.approx(240 / 23)
         assert total_average == pytest.approx(800 / 23)
+
+
+@pytest.mark.asyncio
+async def test_simulation_uses_climb_probability(monkeypatch, setup_database):
+    async with AsyncSessionLocal() as session:
+        season = Season(id=401, year=2025, name="REEFSCAPE Climb Simulation")
+        event = FRCEvent(
+            event_key="2025climbsim",
+            event_name="Climb Simulation Event",
+            short_name="ClimbSim",
+            year=2025,
+            week=1,
+        )
+
+        organization = Organization(name="Climb Org", team_number=9001)
+        now = datetime.utcnow()
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="climb@example.com",
+            auth_provider="discord",
+            display_name="Climb User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        red_teams = [6100, 6101, 6102]
+        blue_teams = [6200, 6201, 6202]
+        team_records = [
+            TeamRecord(team_number=number, team_name=f"Team {number}")
+            for number in red_teams + blue_teams
+        ]
+
+        session.add_all([season, event, organization, user, *team_records])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+
+        schedule = MatchSchedule(
+            event_key=event.event_key,
+            match_number=1,
+            match_level="qm",
+            red1_id=red_teams[0],
+            red2_id=red_teams[1],
+            red3_id=red_teams[2],
+            blue1_id=blue_teams[0],
+            blue2_id=blue_teams[1],
+            blue3_id=blue_teams[2],
+        )
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+
+        session.add_all([schedule, organization_event])
+
+        match_records = []
+        for team_number in red_teams + blue_teams:
+            endgame_value = Endgame2025.DEEP if team_number == red_teams[0] else Endgame2025.NONE
+            match_records.append(
+                MatchData2025(
+                    season=season.id,
+                    team_number=team_number,
+                    event_key=event.event_key,
+                    match_number=1,
+                    match_level="qm",
+                    user_id=user_id,
+                    organization_id=organization.id,
+                    al1c=1,
+                    tl1c=1,
+                    endgame=endgame_value,
+                )
+            )
+
+        session.add_all(match_records)
+        await session.commit()
+
+        original_default_rng = np.random.default_rng
+        monkeypatch.setattr(np.random, "default_rng", lambda: original_default_rng(42))
+
+        results = await simulate_match_prediction(
+            session, event.event_key, "qm", 1
+        )
+
+        org_results = results[int(organization.id)]
+
+        assert org_results["red_endgame_rp"] == pytest.approx(1.0)
+        assert org_results["blue_endgame_rp"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- compute climb success probabilities for each team and carry climb-excluded point statistics into the simulator
- update the Monte Carlo match prediction to draw climb results from a Bernoulli distribution, add 12-point successes to totals, and reuse those outcomes for climb RP odds
- cover the new behavior with an integration test that verifies a guaranteed climb alliance secures the endgame RP

## Testing
- pytest tests/test_match_prediction.py *(fails: missing optional dependency `aiosqlite` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c133148832684b421815b87eb9c