### PR TITLE
Expand scouting alliance data sharing

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum
 from datetime import datetime
 from math import sqrt
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 import httpx
@@ -22,6 +22,8 @@ from models import (
     FRCEvent,
     Organization,
     OrganizationEvent,
+    OrganizationEventAlliance,
+    OrgEventAllianceInviteStatus,
     UserOrganization,
     UserRole,
     EventRankings,
@@ -34,6 +36,62 @@ from services.scoring import (
     resolve_weight_mapping,
 )
 from services.season import get_season_by_year_or_404
+
+
+async def get_scouting_alliance_organization_ids(
+    session: AsyncSession, event_key: str, organization_id: int | None
+) -> Set[int]:
+    """Return organization identifiers accessible through scouting alliances.
+
+    The result always includes ``organization_id`` when provided and adds any
+    organizations that have accepted scouting alliances for the specified
+    ``event_key``. Alliances are considered in both directions so that an
+    organization gains access when it invited another organization or accepted
+    an invitation from someone else.
+    """
+
+    if organization_id is None:
+        return set()
+
+    accessible_ids: Set[int] = {int(organization_id)}
+
+    org_event_statement = select(OrganizationEvent.id).where(
+        OrganizationEvent.event_key == event_key,
+        OrganizationEvent.organization_id == organization_id,
+    )
+    org_event_result = await session.execute(org_event_statement)
+    org_event_id = org_event_result.scalar_one_or_none()
+
+    if org_event_id is not None:
+        outgoing_statement = select(OrganizationEventAlliance.other_organization_id).where(
+            OrganizationEventAlliance.orgevent_Uid == org_event_id,
+            OrganizationEventAlliance.org_invite_status
+            == OrgEventAllianceInviteStatus.ACCEPTED,
+        )
+        outgoing_result = await session.execute(outgoing_statement)
+        accessible_ids.update(
+            org_id for org_id in outgoing_result.scalars().all() if org_id is not None
+        )
+
+    incoming_statement = (
+        select(OrganizationEvent.organization_id)
+        .join(
+            OrganizationEventAlliance,
+            OrganizationEventAlliance.orgevent_Uid == OrganizationEvent.id,
+        )
+        .where(
+            OrganizationEvent.event_key == event_key,
+            OrganizationEventAlliance.other_organization_id == organization_id,
+            OrganizationEventAlliance.org_invite_status
+            == OrgEventAllianceInviteStatus.ACCEPTED,
+        )
+    )
+    incoming_result = await session.execute(incoming_statement)
+    accessible_ids.update(
+        org_id for org_id in incoming_result.scalars().all() if org_id is not None
+    )
+
+    return accessible_ids
 
 class MatchScheduleResponse(SQLModel):
     event_key: str

--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -34,6 +34,7 @@ from services.event import (
     get_active_event_key_for_user,
     get_event_or_404,
     get_match_or_404,
+    get_scouting_alliance_organization_ids,
     update_statbotics_data_for_event,
 )
 from services.scoring import (
@@ -119,14 +120,17 @@ async def _collect_team_records(
     match_model: type[MatchData],
     event_key: str,
     team_number: int,
-    organization_id: int,
+    organization_ids: Sequence[int],
 ) -> List[MatchData]:
+    if not organization_ids:
+        return []
+
     statement = (
         select(match_model)
         .where(
             match_model.event_key == event_key,
             match_model.team_number == team_number,
-            match_model.organization_id == organization_id,
+            match_model.organization_id.in_(list(organization_ids)),
         )
         .order_by(match_model.match_number.desc())
     )
@@ -221,13 +225,13 @@ async def _get_team_statistics(
     match_model: type[MatchData],
     event_key: str,
     team_number: int,
-    organization_id: int,
+    organization_ids: Sequence[int],
     auto_weights: Dict[str, float],
     teleop_weights: Dict[str, float],
     endgame_points: Dict[str, float],
 ) -> Dict[str, Tuple[float, float]]:
     records = await _collect_team_records(
-        session, match_model, event_key, team_number, organization_id
+        session, match_model, event_key, team_number, organization_ids
     )
     if records:
         _apply_calculated_fields(records, auto_weights, teleop_weights, endgame_points)
@@ -407,13 +411,16 @@ async def _fetch_match_records(
     session: AsyncSession,
     model: type[RecordType],
     event_key: str,
-    organization_id: int,
+    organization_ids: Sequence[int],
 ) -> List[RecordType]:
+    if not organization_ids:
+        return []
+
     statement = (
         select(model)
         .where(
             model.event_key == event_key,
-            model.organization_id == organization_id,
+            model.organization_id.in_(list(organization_ids)),
         )
         .order_by(model.match_number.desc())
     )
@@ -440,6 +447,12 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
     match_model = MATCH_DATA_MODELS_BY_YEAR.get(event.year)
     prescout_model = PRESCOUT_MODELS_BY_YEAR.get(event.year)
 
+    alliance_organization_ids = list(
+        await get_scouting_alliance_organization_ids(
+            session, event_key, membership.organization_id
+        )
+    )
+
     seen_matches: Set[Tuple[str, int]] = set()
     ordered_records: List[MatchData] = []
     limit = 10
@@ -456,7 +469,7 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
         )
 
         scouted_records = await _fetch_match_records(
-            session, match_model, event_key, membership.organization_id
+            session, match_model, event_key, alliance_organization_ids
         )
         latest_matches = _collect_latest_matches(
             scouted_records, seen_matches, limit
@@ -478,7 +491,7 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
         )
 
         prescout_records = await _fetch_match_records(
-            session, prescout_model, event_key, membership.organization_id
+            session, prescout_model, event_key, alliance_organization_ids
         )
         latest_prescout = _collect_latest_matches(
             prescout_records, seen_matches, limit
@@ -622,20 +635,32 @@ async def get_match_prediction_for_user_organization(
             detail="Match predictions are not available for this event year",
         )
 
-    prediction = await session.get(
-        prediction_model,
-        (
-            event_key,
-            int(match_number),
-            match_level,
-            int(membership.organization_id),
-        ),
+    alliance_organization_ids = list(
+        await get_scouting_alliance_organization_ids(
+            session, event_key, membership.organization_id
+        )
     )
 
-    if prediction is None:
+    if not alliance_organization_ids:
         raise HTTPException(status_code=404, detail="Match prediction not found")
 
-    return prediction
+    statement = select(prediction_model).where(
+        prediction_model.event_key == event_key,
+        prediction_model.match_number == int(match_number),
+        prediction_model.match_level == match_level,
+        prediction_model.organization_id.in_(alliance_organization_ids),
+    )
+    result = await session.execute(statement)
+    predictions = result.scalars().all()
+
+    if not predictions:
+        raise HTTPException(status_code=404, detail="Match prediction not found")
+
+    for prediction in predictions:
+        if prediction.organization_id == membership.organization_id:
+            return prediction
+
+    return predictions[0]
 
 
 async def simulate_match_prediction(
@@ -679,13 +704,21 @@ async def simulate_match_prediction(
     results: Dict[int, Dict[str, float]] = {}
 
     for organization_id in organization_ids:
+        alliance_organization_ids = list(
+            await get_scouting_alliance_organization_ids(
+                session, event_code, int(organization_id)
+            )
+        )
+        if not alliance_organization_ids:
+            continue
+
         red_stats = [
             await _get_team_statistics(
                 session,
                 match_model,
                 event_code,
                 int(team_number),
-                organization_id,
+                alliance_organization_ids,
                 auto_weights,
                 teleop_weights,
                 endgame_points,
@@ -698,7 +731,7 @@ async def simulate_match_prediction(
                 match_model,
                 event_code,
                 int(team_number),
-                organization_id,
+                alliance_organization_ids,
                 auto_weights,
                 teleop_weights,
                 endgame_points,

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -37,6 +37,7 @@ from services.event import (
     MATCH_DATA_MODELS_BY_YEAR,
     get_active_event_key_for_user,
     get_event_or_404,
+    get_scouting_alliance_organization_ids,
 )
 from services.season import get_season_by_year_or_404
 
@@ -803,9 +804,15 @@ async def get_superscout_records(
             detail="Superscouting is not available for this event",
         )
 
+    alliance_organization_ids = list(
+        await get_scouting_alliance_organization_ids(
+            session, event_key, membership.organization_id
+        )
+    )
+
     statement = select(superscout_model).where(
         superscout_model.event_key == event_key,
-        superscout_model.organization_id == membership.organization_id,
+        superscout_model.organization_id.in_(alliance_organization_ids),
     )
 
     if team_number is not None:
@@ -842,9 +849,15 @@ async def get_superscouted_match_alliances(
     if not match_schedules:
         return []
 
+    alliance_organization_ids = list(
+        await get_scouting_alliance_organization_ids(
+            session, event_key, membership.organization_id
+        )
+    )
+
     superscout_statement = select(superscout_model).where(
         superscout_model.event_key == event_key,
-        superscout_model.organization_id == membership.organization_id,
+        superscout_model.organization_id.in_(alliance_organization_ids),
     )
     superscout_result = await session.execute(superscout_statement)
     superscout_records = superscout_result.scalars().all()

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -7,6 +7,7 @@ from services.event import (
     MATCH_DATA_MODELS_BY_YEAR,
     get_active_event_key_for_user,
     get_event_or_404,
+    get_scouting_alliance_organization_ids,
 )
 
 
@@ -36,10 +37,16 @@ async def get_match_data_for_team_at_active_event(
     if match_model is None:
         raise HTTPException(status_code=404, detail="Match data is not available for this event")
 
+    alliance_organization_ids = list(
+        await get_scouting_alliance_organization_ids(
+            session, event_key, membership.organization_id
+        )
+    )
+
     statement = select(match_model).where(
         match_model.team_number == team_number,
         match_model.event_key == event_key,
-        match_model.organization_id == membership.organization_id,
+        match_model.organization_id.in_(alliance_organization_ids),
     )
     result = await session.execute(statement)
     return result.scalars().all()

--- a/tests/test_scouting_alliance_access.py
+++ b/tests/test_scouting_alliance_access.py
@@ -1,0 +1,245 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from app.models import (
+    FRCEvent,
+    MatchData2025,
+    MatchPredictions2025,
+    MatchSchedule,
+    Organization,
+    OrganizationEvent,
+    OrganizationEventAlliance,
+    OrgEventAllianceInviteStatus,
+    Season,
+    SuperScoutData2025,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from app.services.match_prediction import get_match_prediction_for_user_organization
+from app.services.scout import (
+    get_superscout_records,
+    get_superscouted_match_alliances,
+)
+from app.services.team import get_match_data_for_team_at_active_event
+from tests.conftest import AsyncSessionLocal
+
+
+async def _create_alliance_context(event_key: str, season_id: int) -> dict:
+    async with AsyncSessionLocal() as session:
+        now = datetime.utcnow()
+
+        season = Season(id=season_id, year=2025, name=f"Season {season_id}")
+        event = FRCEvent(
+            event_key=event_key,
+            event_name="Alliance Test Event",
+            short_name="Alliance",
+            year=2025,
+            week=1,
+        )
+        primary_org = Organization(name=f"Primary {event_key}", team_number=season_id)
+        allied_org = Organization(name=f"Allied {event_key}", team_number=season_id + 1)
+
+        primary_user_id = uuid4()
+        allied_user_id = uuid4()
+
+        primary_user = User(
+            id=primary_user_id,
+            email=f"primary-{event_key}@example.com",
+            auth_provider="discord",
+            display_name="Primary User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+        allied_user = User(
+            id=allied_user_id,
+            email=f"allied-{event_key}@example.com",
+            auth_provider="discord",
+            display_name="Allied User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        session.add_all(
+            [season, event, primary_org, allied_org, primary_user, allied_user]
+        )
+        await session.commit()
+        await session.refresh(primary_org)
+        await session.refresh(allied_org)
+
+        primary_membership = UserOrganization(
+            user_id=primary_user_id,
+            organization_id=primary_org.id,
+            role=UserRole.MEMBER,
+        )
+        allied_membership = UserOrganization(
+            user_id=allied_user_id,
+            organization_id=allied_org.id,
+            role=UserRole.MEMBER,
+        )
+        session.add_all([primary_membership, allied_membership])
+        await session.commit()
+        await session.refresh(primary_membership)
+
+        primary_event = OrganizationEvent(
+            organization_id=primary_org.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        allied_event = OrganizationEvent(
+            organization_id=allied_org.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        session.add_all([primary_event, allied_event])
+        await session.commit()
+        await session.refresh(primary_event)
+
+        alliance = OrganizationEventAlliance(
+            orgevent_Uid=primary_event.id,
+            other_organization_id=allied_org.id,
+            org_invite_status=OrgEventAllianceInviteStatus.ACCEPTED,
+        )
+        session.add(alliance)
+        await session.commit()
+
+        return {
+            "season_id": season.id,
+            "event_key": event.event_key,
+            "primary_user_id": primary_user_id,
+            "primary_membership_id": primary_membership.id,
+            "primary_organization_id": primary_org.id,
+            "allied_user_id": allied_user_id,
+            "allied_organization_id": allied_org.id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_match_data_includes_alliance_records(setup_database):
+    context = await _create_alliance_context("2025alliancemd", 9001)
+
+    async with AsyncSessionLocal() as session:
+        team = TeamRecord(teamNumber=1234, teamName="Alliance Team")
+        session.add(team)
+        await session.commit()
+
+        match_entry = MatchData2025(
+            season=context["season_id"],
+            team_number=team.team_number,
+            event_key=context["event_key"],
+            match_number=1,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+        )
+        session.add(match_entry)
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        records = await get_match_data_for_team_at_active_event(
+            session, team.team_number, user_payload
+        )
+
+        assert len(records) == 1
+        assert records[0].organization_id == context["allied_organization_id"]
+
+
+@pytest.mark.asyncio
+async def test_superscout_access_includes_allied_data(setup_database):
+    context = await _create_alliance_context("2025alliancescout", 9002)
+
+    async with AsyncSessionLocal() as session:
+        teams = [
+            TeamRecord(teamNumber=number, teamName=f"Team {number}")
+            for number in range(5001, 5007)
+        ]
+        session.add_all(teams)
+        await session.commit()
+
+        schedule = MatchSchedule(
+            event_key=context["event_key"],
+            match_number=7,
+            match_level="qm",
+            red1_id=5001,
+            red2_id=5002,
+            red3_id=5003,
+            blue1_id=5004,
+            blue2_id=5005,
+            blue3_id=5006,
+        )
+        session.add(schedule)
+        await session.commit()
+
+        superscout_entries = [
+            SuperScoutData2025(
+                season=context["season_id"],
+                team_number=team_number,
+                event_key=context["event_key"],
+                match_number=7,
+                match_level="qm",
+                user_id=context["allied_user_id"],
+                organization_id=context["allied_organization_id"],
+                robot_overall=4,
+            )
+            for team_number in (5001, 5002, 5003)
+        ]
+        session.add_all(superscout_entries)
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        records = await get_superscout_records(session, user_payload)
+        assert len(records) == 3
+        assert {
+            record.organization_id for record in records
+        } == {context["allied_organization_id"]}
+
+        alliances = await get_superscouted_match_alliances(session, user_payload)
+        assert alliances
+        alliance_info = alliances[0]["alliances"]
+        assert alliance_info["red"] is True
+        assert alliance_info["blue"] is False
+
+
+@pytest.mark.asyncio
+async def test_match_prediction_fetches_allied_results(setup_database):
+    context = await _create_alliance_context("2025alliancepred", 9003)
+
+    async with AsyncSessionLocal() as session:
+        prediction = MatchPredictions2025(
+            season=context["season_id"],
+            event_key=context["event_key"],
+            match_number=15,
+            match_level="qm",
+            organization_id=context["allied_organization_id"],
+            red_alliance_win_pct=0.65,
+            blue_alliance_win_pct=0.35,
+        )
+        session.add(prediction)
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        record = await get_match_prediction_for_user_organization(
+            session, user_payload, "qm", 15
+        )
+
+        assert record.organization_id == context["allied_organization_id"]
+        assert record.red_alliance_win_pct == pytest.approx(0.65)


### PR DESCRIPTION
## Summary
- add a shared helper that resolves the organization IDs available through accepted scouting alliances for an event
- update match prediction, match data, and superscout services to pull records for all allied organizations and extend simulations to use the combined datasets
- add coverage that verifies alliance-linked organizations receive match data, superscout results, and stored predictions from their partners

## Testing
- pytest tests/test_scouting_alliance_access.py *(fails: missing `aiosqlite` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57bf3b0ac83269108bd3a3d93a16d