### PR TITLE
Include event year in organization events API response

### DIFF
--- a/app/routes/organizationadmin.py
+++ b/app/routes/organizationadmin.py
@@ -179,6 +179,7 @@ class OrganizationEventDetail(SQLModel):
     eventKey: str
     shortName: str
     eventName: str
+    eventYear: int
     week: int
     isPublic: bool
     isActive: bool
@@ -939,6 +940,7 @@ async def get_organization_events(
             isPublic=organization_event.public_data,
             isActive=organization_event.active,
             eventName=frc_event.event_name,
+            eventYear=frc_event.year,
             shortName=frc_event.short_name,
             eventKey=frc_event.event_key,
             week=frc_event.week,


### PR DESCRIPTION
## Summary
- add an `eventYear` attribute to the organization events response model
- populate the new field from the associated FRC event record when listing organization events

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e5866e54dc8326a8eb0615ef0a0f51