### PR TITLE
Fix organization event lookup using SQLModel ScalarResult

### DIFF
--- a/app/routes/organizationadmin.py
+++ b/app/routes/organizationadmin.py
@@ -247,7 +247,7 @@ async def _get_active_org_event(
         OrganizationEvent.active == True,  # noqa: E712 - SQLAlchemy boolean comparison
     )
     result = await session.exec(statement)
-    org_event = result.scalar_one_or_none()
+    org_event = result.one_or_none()
 
     if org_event is None:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- ensure active organization events are retrieved using `one_or_none` when executing SQLModel queries

## Testing
- pytest *(fails: requires `aiosqlite` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e588d14db48326ac34476307464171