### PR TITLE
Allow scouting alliances to update match data

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -175,10 +175,14 @@ async def _prepare_match_update(
     if membership is None:
         raise HTTPException(status_code=404, detail="Organization membership not found")
 
-    if base_match.organization_id != membership.organization_id:
+    alliance_organization_ids = await get_scouting_alliance_organization_ids(
+        session, event_key, membership.organization_id
+    )
+
+    if base_match.organization_id not in alliance_organization_ids:
         raise HTTPException(
             status_code=403,
-            detail="Match data does not belong to the active organization",
+            detail="Match data does not belong to the active organization or its scouting alliances",
         )
 
     event = await get_event_or_404(session, event_key)
@@ -204,13 +208,15 @@ async def _prepare_match_update(
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail="Invalid match data for this event") from exc
 
+    alliance_organization_ids_tuple = tuple(alliance_organization_ids)
+
     statement = select(match_model).where(
         match_model.event_key == base_match.event_key,
         match_model.match_number == base_match.match_number,
         match_model.match_level == base_match.match_level,
         match_model.team_number == base_match.team_number,
         match_model.user_id == base_match.user_id,
-        match_model.organization_id == membership.organization_id,
+        match_model.organization_id.in_(alliance_organization_ids_tuple),
     )
 
     result = await session.execute(statement)
@@ -222,7 +228,15 @@ async def _prepare_match_update(
     if getattr(stored_match, "season", None) != base_match.season:
         raise HTTPException(status_code=400, detail="Season mismatch for match data update")
 
-    return base_match, match_payload, match_model, membership, typed_match, stored_match
+    return (
+        base_match,
+        match_payload,
+        match_model,
+        membership,
+        typed_match,
+        stored_match,
+        alliance_organization_ids,
+    )
 
 
 def _apply_match_update(
@@ -683,6 +697,7 @@ async def update_match_data_and_mark_validation_valid(
         membership,
         typed_match,
         stored_match,
+        alliance_organization_ids,
     ) = await _prepare_match_update(session, user, match)
 
     payload = _model_dump(typed_match)
@@ -690,13 +705,15 @@ async def update_match_data_and_mark_validation_valid(
 
     session.add(stored_match)
 
+    alliance_organization_ids_tuple = tuple(alliance_organization_ids)
+
     validation_statement = select(DataValidation).where(
         DataValidation.event_key == base_match.event_key,
         DataValidation.match_number == base_match.match_number,
         DataValidation.match_level == base_match.match_level,
         DataValidation.team_number == base_match.team_number,
         DataValidation.user_id == base_match.user_id,
-        DataValidation.organization_id == membership.organization_id,
+        DataValidation.organization_id.in_(alliance_organization_ids_tuple),
     )
 
     validation_result = await session.execute(validation_statement)
@@ -1435,6 +1452,7 @@ async def update_scouted_match(session: AsyncSession, match: MatchData, user: Us
         _membership,
         typed_match,
         stored_match,
+        _alliance_organization_ids,
     ) = await _prepare_match_update(session, user, match)
 
     updated_payload = _model_dump(typed_match)

--- a/tests/test_scouting_alliance_access.py
+++ b/tests/test_scouting_alliance_access.py
@@ -6,6 +6,7 @@ from sqlmodel import select
 
 from app.models import (
     DataValidation,
+    Endgame2025,
     FRCEvent,
     MatchData2025,
     MatchPredictions2025,
@@ -20,14 +21,18 @@ from app.models import (
     User,
     UserOrganization,
     UserRole,
+    ValidationStatus,
 )
 from app.services.event import get_scouting_alliance_organization_ids
 from app.services.match_prediction import get_match_prediction_for_user_organization
 from app.services.scout import (
     DataValidationFilterRequest,
+    DataValidationUpdateRequest,
+    batch_update_data_validations,
     get_data_validations_for_active_event,
     get_superscout_records,
     get_superscouted_match_alliances,
+    update_match_data_and_mark_validation_valid,
 )
 from app.services.team import get_match_data_for_team_at_active_event
 from tests.conftest import AsyncSessionLocal
@@ -315,6 +320,166 @@ async def test_data_validation_pull_includes_incoming_allied_records(setup_datab
 
         assert len(records) == 1
         assert records[0].organization_id == context["allied_organization_id"]
+
+
+@pytest.mark.asyncio
+async def test_allied_user_can_update_data_validation(setup_database):
+    context = await _create_alliance_context("2025alliancedvupdate", 9102)
+
+    async with AsyncSessionLocal() as session:
+        team = TeamRecord(teamNumber=6300, teamName="Alliance Update Team")
+        session.add(team)
+        await session.commit()
+
+        match_entry = MatchData2025(
+            season=context["season_id"],
+            team_number=team.team_number,
+            event_key=context["event_key"],
+            match_number=5,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+            al4c=1,
+            tl4c=1,
+            aNet=0,
+            tProcessor=0,
+            endgame=Endgame2025.NONE,
+        )
+        validation_record = DataValidation(
+            event_key=context["event_key"],
+            match_number=5,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            team_number=team.team_number,
+            organization_id=context["allied_organization_id"],
+            validation_status=ValidationStatus.PENDING,
+        )
+
+        session.add_all([match_entry, validation_record])
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        update_request = DataValidationUpdateRequest(
+            matchNumber=5,
+            matchLevel="qm",
+            teamNumber=team.team_number,
+            userId=context["allied_user_id"],
+            validationStatus=ValidationStatus.NEEDS_REVIEW,
+            notes="Alliance review",
+        )
+
+        updated_records = await batch_update_data_validations(
+            session, user_payload, [update_request]
+        )
+
+        assert len(updated_records) == 1
+        updated_record = updated_records[0]
+        assert updated_record.organization_id == context["allied_organization_id"]
+        assert updated_record.validation_status == ValidationStatus.NEEDS_REVIEW
+        assert updated_record.notes == "Alliance review"
+
+        validation_stmt = select(DataValidation).where(
+            DataValidation.event_key == context["event_key"],
+            DataValidation.match_number == 5,
+            DataValidation.match_level == "qm",
+            DataValidation.team_number == team.team_number,
+            DataValidation.user_id == context["allied_user_id"],
+        )
+        validation_result = await session.execute(validation_stmt)
+        stored_validation = validation_result.scalars().first()
+
+        assert stored_validation is not None
+        assert stored_validation.validation_status == ValidationStatus.NEEDS_REVIEW
+        assert stored_validation.notes == "Alliance review"
+
+
+@pytest.mark.asyncio
+async def test_allied_user_can_update_match_data(setup_database):
+    context = await _create_alliance_context("2025alliancematchupdate", 9103)
+
+    async with AsyncSessionLocal() as session:
+        team = TeamRecord(teamNumber=6400, teamName="Alliance Match Team")
+        session.add(team)
+        await session.commit()
+
+        match_entry = MatchData2025(
+            season=context["season_id"],
+            team_number=team.team_number,
+            event_key=context["event_key"],
+            match_number=6,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+            notes="Original alliance notes",
+            al4c=2,
+            tl4c=1,
+            aNet=1,
+            tProcessor=0,
+            endgame=Endgame2025.PARK,
+        )
+        validation_record = DataValidation(
+            event_key=context["event_key"],
+            match_number=6,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            team_number=team.team_number,
+            organization_id=context["allied_organization_id"],
+            validation_status=ValidationStatus.PENDING,
+            notes="",
+        )
+
+        session.add_all([match_entry, validation_record])
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        updated_match = MatchData2025(
+            season=context["season_id"],
+            team_number=team.team_number,
+            event_key=context["event_key"],
+            match_number=6,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+            notes="Alliance correction",
+            al4c=3,
+            tl4c=2,
+            aNet=1,
+            tProcessor=1,
+            endgame=Endgame2025.DEEP,
+        )
+
+        validation = await update_match_data_and_mark_validation_valid(
+            session, user_payload, updated_match
+        )
+
+        assert validation.organization_id == context["allied_organization_id"]
+        assert validation.validation_status == ValidationStatus.VALID
+        assert validation.notes == "Alliance correction"
+
+        match_stmt = select(MatchData2025).where(
+            MatchData2025.event_key == context["event_key"],
+            MatchData2025.match_number == 6,
+            MatchData2025.match_level == "qm",
+            MatchData2025.team_number == team.team_number,
+            MatchData2025.user_id == context["allied_user_id"],
+        )
+        match_result = await session.execute(match_stmt)
+        stored_match = match_result.scalars().first()
+
+        assert stored_match is not None
+        assert stored_match.al4c == 3
+        assert stored_match.tl4c == 2
+        assert stored_match.tProcessor == 1
+        assert stored_match.endgame == Endgame2025.DEEP
+        assert stored_match.notes == "Original alliance notes"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow match data updates and validation checks when the record belongs to an allied scouting organization
- permit data validation batch updates across scouting alliances and cover the behavior with new tests

## Testing
- `pytest tests/test_scouting_alliance_access.py::test_allied_user_can_update_data_validation -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68e5a56e51188326b9a0904724e433f0