### PR TITLE
Ensure match prediction data prefers member org

### DIFF
--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -387,14 +387,30 @@ def _collect_latest_matches(
     records: Sequence[RecordType],
     seen_matches: Set[Tuple[str, int]],
     limit: int,
+    preferred_organization_id: int | None = None,
 ) -> List[RecordType]:
     collected: List[RecordType] = []
     unique_matches = len(seen_matches)
+    collected_index: Dict[Tuple[str, int], int] = {}
 
     for record in records:
         match_identifier = (record.match_level, record.match_number)
         if match_identifier in seen_matches:
-            collected.append(record)
+            if preferred_organization_id is None:
+                continue
+
+            existing_index = collected_index.get(match_identifier)
+            if existing_index is None:
+                continue
+
+            preferred_existing = (
+                getattr(collected[existing_index], "organization_id", None)
+                == preferred_organization_id
+            )
+            is_preferred = getattr(record, "organization_id", None) == preferred_organization_id
+
+            if is_preferred and not preferred_existing:
+                collected[existing_index] = record
             continue
 
         if unique_matches >= limit:
@@ -402,6 +418,7 @@ def _collect_latest_matches(
 
         seen_matches.add(match_identifier)
         unique_matches += 1
+        collected_index[match_identifier] = len(collected)
         collected.append(record)
 
     return collected
@@ -472,7 +489,10 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
             session, match_model, event_key, alliance_organization_ids
         )
         latest_matches = _collect_latest_matches(
-            scouted_records, seen_matches, limit
+            scouted_records,
+            seen_matches,
+            limit,
+            preferred_organization_id=membership.organization_id,
         )
         _apply_calculated_fields(
             latest_matches, auto_weights, teleop_weights, endgame_points
@@ -494,7 +514,10 @@ async def retrieve_prediction_data(session: AsyncSession, user: Any) -> List[Mat
             session, prescout_model, event_key, alliance_organization_ids
         )
         latest_prescout = _collect_latest_matches(
-            prescout_records, seen_matches, limit
+            prescout_records,
+            seen_matches,
+            limit,
+            preferred_organization_id=membership.organization_id,
         )
         _apply_calculated_fields(
             latest_prescout,

--- a/tests/test_match_prediction.py
+++ b/tests/test_match_prediction.py
@@ -11,6 +11,8 @@ from app.models import (
     MatchSchedule,
     Organization,
     OrganizationEvent,
+    OrganizationEventAlliance,
+    OrgEventAllianceInviteStatus,
     Season,
     StatboticsData,
     TeamRecord,
@@ -231,6 +233,105 @@ async def test_statbotics_data_supplements_weighted_statistics(setup_database):
         assert teleop_average == pytest.approx(175 / 23)
         assert endgame_average == pytest.approx(126 / 23)
         assert total_average == pytest.approx(642 / 23)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_prediction_data_prefers_logged_in_org(setup_database):
+    async with AsyncSessionLocal() as session:
+        season = Season(id=210, year=2025, name="REEFSCAPE Alliance Preference")
+        event = FRCEvent(
+            event_key="2025alliancepref",
+            event_name="Alliance Preference Event",
+            short_name="AlliancePref",
+            year=2025,
+            week=1,
+        )
+
+        primary_org = Organization(name="Primary Org", team_number=5555)
+        secondary_org = Organization(name="Secondary Org", team_number=6666)
+        now = datetime.utcnow()
+        user_id = uuid4()
+        user = User(
+            id=user_id,
+            email="primary@example.com",
+            auth_provider="discord",
+            display_name="Primary User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        session.add_all([season, event, primary_org, secondary_org, user])
+        await session.commit()
+        await session.refresh(primary_org)
+        await session.refresh(secondary_org)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=primary_org.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        primary_event = OrganizationEvent(
+            organization_id=primary_org.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        secondary_event = OrganizationEvent(
+            organization_id=secondary_org.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        session.add_all([primary_event, secondary_event])
+        await session.commit()
+        await session.refresh(primary_event)
+
+        alliance = OrganizationEventAlliance(
+            orgevent_Uid=primary_event.id,
+            other_organization_id=secondary_org.id,
+            org_invite_status=OrgEventAllianceInviteStatus.ACCEPTED,
+        )
+        session.add(alliance)
+
+        session.add_all(
+            [
+                MatchData2025(
+                    season=season.id,
+                    team_number=1111,
+                    event_key=event.event_key,
+                    match_number=1,
+                    match_level="qm",
+                    user_id=user_id,
+                    organization_id=secondary_org.id,
+                    tl1c=5,
+                ),
+                MatchData2025(
+                    season=season.id,
+                    team_number=1111,
+                    event_key=event.event_key,
+                    match_number=1,
+                    match_level="qm",
+                    user_id=user_id,
+                    organization_id=primary_org.id,
+                    al1c=2,
+                ),
+            ]
+        )
+
+        await session.commit()
+
+        user_payload = {"id": str(user_id), "user_org": membership.id}
+
+        matches = await retrieve_prediction_data(session, user_payload)
+
+        assert len(matches) == 1
+        match = matches[0]
+        assert match.organization_id == primary_org.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deduplicate match prediction inputs so only one record per match is used and prefer the logged-in organization's scouting data
- extend match prediction tests to cover alliance data selection priorities

## Testing
- pytest tests/test_match_prediction.py::test_retrieve_prediction_data_prefers_logged_in_org *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e5bba80c2883268e8ff17c503ced79