### PR TITLE
Add public API routes for events, teams, and seasons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from routes import (
     event,
     organizationadmin,
     picklist,
+    public,
     scout,
     season,
     team,
@@ -36,6 +37,7 @@ app.include_router(picklist.router)
 app.include_router(scout.router)
 app.include_router(team.router)
 app.include_router(season.router)
+app.include_router(public.router)
 
 @app.get("/ping")
 def ping():

--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -1,0 +1,56 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from db.database import get_session
+from models import Season, TeamEvent, TeamRecord
+from services.event import (
+    EventResponse,
+    MatchScheduleResponse,
+    get_event_list_or_404,
+    get_event_teams_or_404,
+    get_match_schedule_or_404,
+)
+from services.season import get_seasons
+from services.team import get_team_records_page
+
+router = APIRouter(prefix="/public", tags=["Public"])
+
+
+@router.get("/events/{year}", response_model=List[EventResponse])
+async def get_public_events(
+    year: int, session: AsyncSession = Depends(get_session)
+) -> List[EventResponse]:
+    return await get_event_list_or_404(session, year)
+
+
+@router.get(
+    "/matchSchedule/{eventCode}", response_model=List[MatchScheduleResponse]
+)
+async def get_public_match_schedule(
+    eventCode: str, session: AsyncSession = Depends(get_session)
+) -> List[MatchScheduleResponse]:
+    return await get_match_schedule_or_404(session, eventCode)
+
+
+@router.get("/teams", response_model=List[TeamRecord])
+async def get_public_teams(
+    page: int = Query(1, ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> List[TeamRecord]:
+    return await get_team_records_page(session, page)
+
+
+@router.get("/seasons", response_model=List[Season])
+async def get_public_seasons(
+    session: AsyncSession = Depends(get_session),
+) -> List[Season]:
+    return await get_seasons(session)
+
+
+@router.get("/event/teams/{eventCode}", response_model=List[TeamEvent])
+async def get_public_event_teams(
+    eventCode: str, session: AsyncSession = Depends(get_session)
+) -> List[TeamEvent]:
+    return await get_event_teams_or_404(session, eventCode)

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -259,6 +259,19 @@ async def get_match_schedule_or_404(session: AsyncSession, eventCode: str) -> Li
     return matches
 
 
+async def get_event_teams_or_404(session: AsyncSession, eventCode: str) -> List[TeamEvent]:
+    statement = (
+        select(TeamEvent)
+        .where(TeamEvent.event_key == eventCode)
+        .order_by(TeamEvent.team_number)
+    )
+    result = await session.execute(statement)
+    teams = result.scalars().all()
+    if not teams:
+        raise HTTPException(status_code=404, detail="No teams found for this event")
+    return teams
+
+
 async def get_match_data_for_event_or_404(
     session: AsyncSession,
     eventCode: str,

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -18,6 +20,27 @@ async def get_team_or_404(session: AsyncSession, team_number: int) -> TeamRecord
     if team is None:
         raise HTTPException(status_code=404, detail="Team not found")
     return team
+
+
+async def get_team_records_page(
+    session: AsyncSession,
+    page: int,
+    page_size: int = 500,
+) -> List[TeamRecord]:
+    if page < 1:
+        raise HTTPException(status_code=400, detail="Page must be greater than 0")
+
+    statement = (
+        select(TeamRecord)
+        .order_by(TeamRecord.team_number)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    result = await session.execute(statement)
+    teams = result.scalars().all()
+    if not teams and page != 1:
+        raise HTTPException(status_code=404, detail="No teams found for this page")
+    return teams
 
 
 async def get_match_data_for_team_at_active_event(


### PR DESCRIPTION
## Summary
- add a dedicated /public router exposing unauthenticated endpoints for events, match schedules, teams, seasons, and event team listings
- add pagination helper for team records and event team retrieval service helpers
- register the new public router with the FastAPI application

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e69f8517708326b55aa3bff68f150b