### PR TITLE
Add pagination metadata to public teams endpoint

### DIFF
--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from db.database import get_session
 from models import Season, TeamEvent, TeamRecord
+from pydantic import BaseModel
 from services.event import (
     EventResponse,
     MatchScheduleResponse,
@@ -14,6 +15,22 @@ from services.event import (
 )
 from services.season import get_seasons
 from services.team import get_team_records_page
+
+
+class PaginationMeta(BaseModel):
+    page: int
+    currentPage: int
+    pageSize: int
+    totalItems: int
+    totalPages: int
+    lastPage: int
+    hasNext: bool
+    nextPage: Optional[int] = None
+
+
+class PaginatedTeamRecordsResponse(BaseModel):
+    data: List[TeamRecord]
+    meta: PaginationMeta
 
 router = APIRouter(prefix="/public", tags=["Public"])
 
@@ -34,12 +51,13 @@ async def get_public_match_schedule(
     return await get_match_schedule_or_404(session, eventCode)
 
 
-@router.get("/teams", response_model=List[TeamRecord])
+@router.get("/teams", response_model=PaginatedTeamRecordsResponse)
 async def get_public_teams(
     page: int = Query(1, ge=1),
     session: AsyncSession = Depends(get_session),
-) -> List[TeamRecord]:
-    return await get_team_records_page(session, page)
+) -> PaginatedTeamRecordsResponse:
+    teams, meta = await get_team_records_page(session, page)
+    return PaginatedTeamRecordsResponse(data=teams, meta=meta)
 
 
 @router.get("/seasons", response_model=List[Season])

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -1,6 +1,8 @@
-from typing import List
+from math import ceil
+from typing import Dict, List, Tuple
 
 from fastapi import HTTPException
+from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -26,9 +28,19 @@ async def get_team_records_page(
     session: AsyncSession,
     page: int,
     page_size: int = 500,
-) -> List[TeamRecord]:
+) -> Tuple[List[TeamRecord], Dict[str, int | bool | None]]:
     if page < 1:
         raise HTTPException(status_code=400, detail="Page must be greater than 0")
+
+    total_result = await session.execute(
+        select(func.count()).select_from(TeamRecord)
+    )
+    total_records = total_result.scalar_one()
+
+    total_pages = ceil(total_records / page_size) if total_records else 0
+
+    if total_pages and page > total_pages:
+        raise HTTPException(status_code=404, detail="No teams found for this page")
 
     statement = (
         select(TeamRecord)
@@ -40,7 +52,21 @@ async def get_team_records_page(
     teams = result.scalars().all()
     if not teams and page != 1:
         raise HTTPException(status_code=404, detail="No teams found for this page")
-    return teams
+
+    has_next = total_pages != 0 and page < total_pages
+
+    meta: Dict[str, int | bool | None] = {
+        "page": page,
+        "currentPage": page,
+        "pageSize": page_size,
+        "totalItems": total_records,
+        "totalPages": total_pages,
+        "lastPage": total_pages,
+        "hasNext": has_next,
+        "nextPage": page + 1 if has_next else None,
+    }
+
+    return teams, meta
 
 
 async def get_match_data_for_team_at_active_event(


### PR DESCRIPTION
## Summary
- add pagination metadata to the public teams endpoint so clients can determine if more pages exist
- compute total team counts in the team service and return pagination details alongside each page

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e81c2597b083269b58638911db2a59