### PR TITLE
Look up user membership from database

### DIFF
--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from math import sqrt
 from numbers import Number
 from typing import Any, DefaultDict, Dict, List, Sequence, Set, Tuple, TypeVar
+from uuid import UUID
 
 import numpy as np
 from fastapi import HTTPException
@@ -21,6 +22,7 @@ from models import (
     Prescout2025,
     Season,
     StatboticsData,
+    User,
     UserOrganization,
 )
 from services.event import (
@@ -372,13 +374,30 @@ def _normalize_user_payload(user: Any) -> Dict[str, Any]:
 async def _get_user_membership_or_404(
     session: AsyncSession, user_payload: Dict[str, Any]
 ) -> UserOrganization:
-    membership_id = user_payload.get("user_org")
+    user_id = user_payload.get("id")
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    if not isinstance(user_id, UUID):
+        try:
+            user_id = UUID(str(user_id))
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            raise HTTPException(status_code=400, detail="Invalid user identifier") from exc
+
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    membership_id = user.logged_in_user_org
     if membership_id is None:
         raise HTTPException(status_code=404, detail="User is not logged into an organization")
 
     membership = await session.get(UserOrganization, membership_id)
     if membership is None:
         raise HTTPException(status_code=404, detail="Organization membership not found")
+
+    if membership.user_id != user.id:
+        raise HTTPException(status_code=403, detail="User does not belong to this organization")
 
     return membership
 

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1038,13 +1038,22 @@ async def _normalize_user_id(user_payload: Dict[str, Any]) -> UUID:
 async def _get_user_membership_or_404(
     session: AsyncSession, user_payload: Dict[str, Any]
 ) -> UserOrganization:
-    membership_id = user_payload.get("user_org")
+    user_id = await _normalize_user_id(user_payload)
+
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    membership_id = user.logged_in_user_org
     if membership_id is None:
         raise HTTPException(status_code=404, detail="User is not logged into an organization")
 
     membership = await session.get(UserOrganization, membership_id)
     if membership is None:
         raise HTTPException(status_code=404, detail="Organization membership not found")
+
+    if membership.user_id != user.id:
+        raise HTTPException(status_code=403, detail="User does not belong to this organization")
 
     return membership
 


### PR DESCRIPTION
## Summary
- resolve membership lookups for scouting and prediction services by loading the authenticated user from the database
- derive the active organization from the stored logged-in organization on the user record and validate ownership

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68ef15667b4c8326b306eb73795bb173