### PR TITLE
Add endpoints for listing scouted and pit-scouted entries

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -32,12 +32,14 @@ from services.scout import (
     create_pit_scout_record,
     delete_pit_scout_record,
     get_already_scouted_matches,
+    get_data_validations_for_active_event,
+    get_pit_scout_records,
+    get_pit_scout_summaries,
     get_prescout_records,
+    get_scouted_match_summaries,
     get_superscout_field_options,
     get_superscout_records,
     get_superscouted_match_alliances,
-    get_data_validations_for_active_event,
-    get_pit_scout_records,
     PitScoutDeleteRequest,
     PRESCOUT_MODELS_BY_YEAR,
     SUPERSCOUT_MODELS_BY_YEAR,
@@ -61,6 +63,36 @@ class SuperScoutMatchAllianceStatus(BaseModel):
     matchNumber: int
     red: bool
     blue: bool
+
+
+class ScoutedMatchSummary(BaseModel):
+    event_code: str
+    team_number: int
+    match_number: int
+    match_level: str
+    organization_id: int
+
+
+class PitScoutSummary(BaseModel):
+    event_code: str
+    team_number: int
+    organization_id: int
+
+
+@router.get("/scouted", response_model=List[ScoutedMatchSummary])
+async def list_scouted_matches(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_scouted_match_summaries(session, user)
+
+
+@router.get("/pitscouted", response_model=List[PitScoutSummary])
+async def list_pit_scouted_teams(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_pit_scout_summaries(session, user)
 
 
 @router.get("/dataValidation", response_model=List[DataValidation])

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -787,6 +787,53 @@ class ScoutMatchFilterRequest(SQLModel):
     teamNumber: Optional[int] = None
 
 
+async def get_scouted_match_summaries(
+    session: AsyncSession,
+    user: Any,
+) -> List[Dict[str, Any]]:
+    user_payload = _normalize_user_payload(user)
+
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+
+    membership = await _get_user_membership_or_404(session, user_payload)
+
+    match_model = MATCH_DATA_MODELS_BY_YEAR.get(event.year)
+    if match_model is None:
+        raise HTTPException(status_code=404, detail="Match data is not available for this event")
+
+    alliance_organization_ids = await get_scouting_alliance_organization_ids(
+        session, event_key, membership.organization_id
+    )
+
+    if not alliance_organization_ids:
+        return []
+
+    statement = (
+        select(
+            match_model.event_key.label("event_code"),
+            match_model.team_number.label("team_number"),
+            match_model.match_number.label("match_number"),
+            match_model.match_level.label("match_level"),
+            match_model.organization_id.label("organization_id"),
+        )
+        .where(
+            match_model.event_key == event_key,
+            match_model.organization_id.in_(tuple(alliance_organization_ids)),
+        )
+        .distinct()
+        .order_by(
+            match_model.match_level,
+            match_model.match_number,
+            match_model.team_number,
+            match_model.organization_id,
+        )
+    )
+
+    result = await session.execute(statement)
+    return [dict(row) for row in result.mappings().all()]
+
+
 async def get_already_scouted_matches(
     session: AsyncSession,
     user: dict,
@@ -1132,6 +1179,47 @@ def _get_pit_model_for_event(event_year: int) -> type[PitScout]:
         raise HTTPException(status_code=404, detail="Pit scouting is not available for this event year")
 
     return pit_model
+
+
+async def get_pit_scout_summaries(
+    session: AsyncSession,
+    user: Any,
+) -> List[Dict[str, Any]]:
+    user_payload = _normalize_user_payload(user)
+
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+
+    membership = await _get_user_membership_or_404(session, user_payload)
+
+    pit_model = _get_pit_model_for_event(event.year)
+
+    alliance_organization_ids = await get_scouting_alliance_organization_ids(
+        session, event_key, membership.organization_id
+    )
+
+    if not alliance_organization_ids:
+        return []
+
+    statement = (
+        select(
+            pit_model.event_key.label("event_code"),
+            pit_model.team_number.label("team_number"),
+            pit_model.organization_id.label("organization_id"),
+        )
+        .where(
+            pit_model.event_key == event_key,
+            pit_model.organization_id.in_(tuple(alliance_organization_ids)),
+        )
+        .distinct()
+        .order_by(
+            pit_model.team_number,
+            pit_model.organization_id,
+        )
+    )
+
+    result = await session.execute(statement)
+    return [dict(row) for row in result.mappings().all()]
 
 
 async def get_pit_scout_records(


### PR DESCRIPTION
## Summary
- add a /scout/scouted endpoint that lists distinct scouted match entries for the active event
- add a /scout/pitscouted endpoint that lists distinct pit-scouted entries for the active event

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68efca0e82908326a2d28e0a4b598bbb