### PR TITLE
Add batch pit scouting submission endpoint

### DIFF
--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -26,6 +26,7 @@ from services.scout import (
     DataValidationFilterRequest,
     DataValidationUpdateRequest,
     ScoutMatchFilterRequest,
+    batch_create_pit_scout_records,
     batch_submit_match,
     batch_update_data_validations,
     batch_update_match,
@@ -258,6 +259,15 @@ async def create_pit_scout_entry(
     session: AsyncSession = Depends(get_session),
 ):
     return await create_pit_scout_record(session, pit, user)
+
+
+@router.post("/pit/batch")
+async def create_multiple_pit_scout_entries(
+    pits: List[Dict[str, Any]] = Body(...),
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    return await batch_create_pit_scout_records(session, pits, user)
 
 
 @router.patch("/pit", response_model=PitScoutResponse)

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1388,6 +1388,20 @@ async def create_pit_scout_record(
     return typed_pit
 
 
+async def batch_create_pit_scout_records(
+    session: AsyncSession,
+    pits: Sequence[Union[Dict[str, Any], PitScout]],
+    user: Any,
+) -> None:
+    for pit in pits:
+        try:
+            await create_pit_scout_record(session, pit, user)
+        except HTTPException as exc:
+            if exc.status_code == 409:
+                continue
+            raise
+
+
 async def update_pit_scout_record(
     session: AsyncSession,
     pit: Union[Dict[str, Any], PitScout],

--- a/tests/test_pit_routes.py
+++ b/tests/test_pit_routes.py
@@ -42,8 +42,12 @@ async def _prepare_pit_scouting_data():
             updated_at=datetime.utcnow(),
         )
         team = TeamRecord(teamNumber=9999, teamName="Team 9999")
+        extra_teams = [
+            TeamRecord(teamNumber=8888, teamName="Team 8888"),
+            TeamRecord(teamNumber=7777, teamName="Team 7777"),
+        ]
 
-        session.add_all([season, event, organization, user, team])
+        session.add_all([season, event, organization, user, team, *extra_teams])
         await session.commit()
         await session.refresh(organization)
 
@@ -73,6 +77,7 @@ async def _prepare_pit_scouting_data():
             "organization_id": organization.id,
             "season_id": season.id,
             "team_number": team.teamNumber,
+            "extra_team_numbers": [team.teamNumber for team in extra_teams],
         }
 
 
@@ -144,3 +149,36 @@ def test_pit_scout_crud_flow(pit_client):
     final_list = client.get("/scout/pit")
     assert final_list.status_code == 200
     assert final_list.json() == []
+
+
+def test_pit_scout_batch_submission(pit_client):
+    client, data = pit_client
+
+    batch_payload = [
+        {
+            "team_number": team_number,
+            "notes": f"Pit notes for {team_number}",
+            "robot_weight": 110 + index,
+            "drivetrain": "SWERVE",
+            "autoCoralCount": index,
+            "teleNotes": f"Tele notes {team_number}",
+            "overallNotes": f"Overall notes {team_number}",
+        }
+        for index, team_number in enumerate(data["extra_team_numbers"], start=1)
+    ]
+
+    response = client.post("/scout/pit/batch", json=batch_payload)
+    assert response.status_code == 200
+
+    list_response = client.get("/scout/pit")
+    assert list_response.status_code == 200
+    records = list_response.json()
+    assert len(records) == len(batch_payload)
+    returned_team_numbers = {record["team_number"] for record in records}
+    assert returned_team_numbers == set(data["extra_team_numbers"])
+
+    for team_number in data["extra_team_numbers"]:
+        delete_response = client.request(
+            "DELETE", "/scout/pit", json={"team_number": team_number}
+        )
+        assert delete_response.status_code == 204


### PR DESCRIPTION
## Summary
- add a /scout/pit/batch endpoint that reuses the existing scout authentication flow
- implement a batch pit scouting service helper that iterates over incoming payloads
- expand pit route tests to cover batch submission handling

## Testing
- pytest tests/test_pit_routes.py *(fails: missing `aiosqlite` dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eff67106548326a64ef7c28196e0f8