### PR TITLE
Skip duplicates in batch match submissions

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1715,7 +1715,7 @@ async def batch_submit_match(
         try:
             await submit_scouted_match(session, match, user)
         except HTTPException as exc:
-            if exc.status_code == 304:
+            if exc.status_code in (304, 409):
                 continue
             raise
 

--- a/tests/test_match_submission_payload_aliases.py
+++ b/tests/test_match_submission_payload_aliases.py
@@ -139,3 +139,59 @@ def test_submit_match_accepts_camel_case_payload_aliases(setup_database):
     stored_match = asyncio.run(_fetch_match())
     assert stored_match is not None
     assert stored_match.notes == payload["notes"]
+
+
+def test_batch_submit_match_skips_duplicates(setup_database):
+    context = asyncio.run(_prepare_match_submission_context())
+
+    async def override_current_user():
+        return {
+            "id": str(context["user_id"]),
+            "displayName": "Alias User",
+            "email": "alias@example.com",
+            "user_org": context["membership_id"],
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    payload = {
+        "team_number": context["team_number"],
+        "match_number": 71,
+        "match_level": "qm",
+        "notes": "Duplicate batch match",
+        "endgame": Endgame2025.DEEP.value,
+        "event_key": context["event_key"],
+        "a_net": 0,
+        "a_processor": 0,
+        "al1c": 0,
+        "al2c": 0,
+        "al3c": 0,
+        "al4c": 0,
+        "t_net": 0,
+        "t_processor": 0,
+        "tl1c": 0,
+        "tl2c": 0,
+        "tl3c": 0,
+        "tl4c": 0,
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/scout/submit/batch", json=[payload, payload])
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 200
+
+    async def _fetch_matches():
+        async with AsyncSessionLocal() as session:
+            statement = select(MatchData2025).where(
+                MatchData2025.event_key == context["event_key"],
+                MatchData2025.match_number == payload["match_number"],
+                MatchData2025.match_level == payload["match_level"],
+                MatchData2025.team_number == context["team_number"],
+            )
+            result = await session.execute(statement)
+            return result.scalars().all()
+
+    stored_matches = asyncio.run(_fetch_matches())
+    assert len(stored_matches) == 1


### PR DESCRIPTION
## Summary
- skip duplicate match submissions during batch processing without raising an error
- add regression test ensuring duplicate matches in a batch request are ignored

## Testing
- pytest tests/test_match_submission_payload_aliases.py::test_batch_submit_match_skips_duplicates (fails: missing dependency `aiosqlite` in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f00bb7c6cc83268c8c6f747d4f7a75