### PR TITLE
Fix prescout schema to store 2025 scoring metrics

### DIFF
--- a/alembic/versions/1b7d8b3a3b8d_expand_prescout2025_schema.py
+++ b/alembic/versions/1b7d8b3a3b8d_expand_prescout2025_schema.py
@@ -1,0 +1,82 @@
+"""Expand prescout2025 schema with 2025 scoring fields
+
+Revision ID: 1b7d8b3a3b8d
+Revises: 033016c23fe8
+Create Date: 2025-02-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1b7d8b3a3b8d"
+down_revision: Union[str, Sequence[str], None] = "033016c23fe8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    enum_type = sa.Enum(
+        "NONE",
+        "PARK",
+        "SHALLOW",
+        "DEEP",
+        name="endgame2025",
+        create_type=False,
+    )
+
+    numeric_columns = [
+        "al4c",
+        "al3c",
+        "al2c",
+        "al1c",
+        "tl4c",
+        "tl3c",
+        "tl2c",
+        "tl1c",
+        "aNet",
+        "tNet",
+        "aProcessor",
+        "tProcessor",
+    ]
+
+    for column_name in numeric_columns:
+        op.add_column(
+            "prescout2025",
+            sa.Column(column_name, sa.Integer(), nullable=False, server_default="0"),
+        )
+        op.alter_column("prescout2025", column_name, server_default=None)
+
+    op.add_column(
+        "prescout2025",
+        sa.Column("endgame", enum_type, nullable=False, server_default="NONE"),
+    )
+    op.alter_column("prescout2025", "endgame", server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_column("prescout2025", "endgame")
+
+    for column_name in [
+        "tProcessor",
+        "aProcessor",
+        "tNet",
+        "aNet",
+        "tl1c",
+        "tl2c",
+        "tl3c",
+        "tl4c",
+        "al1c",
+        "al2c",
+        "al3c",
+        "al4c",
+    ]:
+        op.drop_column("prescout2025", column_name)

--- a/app/models/match_data_2025.py
+++ b/app/models/match_data_2025.py
@@ -35,8 +35,8 @@ class MatchData2025(MatchData, table=True):
     endgame: Endgame2025 = Field(default=Endgame2025.NONE)
 
 
-class Prescout2025(MatchData, table=True):
-    """Prescout table that shares the base match-scoped columns."""
+class Prescout2025(MatchData2025, table=True):
+    """Prescout table that reuses the 2025 scoring schema."""
 
     __tablename__ = "prescout2025"
 

--- a/tests/test_prescout_submission.py
+++ b/tests/test_prescout_submission.py
@@ -1,0 +1,141 @@
+import asyncio
+from datetime import datetime
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+from app.auth.dependencies import get_current_user
+from app.main import app
+from app.models import (
+    Endgame2025,
+    FRCEvent,
+    Organization,
+    OrganizationEvent,
+    Prescout2025,
+    Season,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_prescout_context():
+    async with AsyncSessionLocal() as session:
+        season = Season(id=99, year=2025, name="REEFSCAPE")
+        event = FRCEvent(
+            event_key="2025prescouttest",
+            event_name="Prescout Test Event",
+            short_name="Prescout",
+            year=2025,
+            week=5,
+        )
+        organization = Organization(name="Prescout Org", team_number=51)
+        team = TeamRecord(teamNumber=51, teamName="Team 51")
+        user_id = uuid4()
+        now = datetime.utcnow()
+        user = User(
+            id=user_id,
+            email="prescout@example.com",
+            auth_provider="discord",
+            display_name="Prescout User",
+            logged_in_user_org=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        session.add_all([season, event, organization, team, user])
+        await session.commit()
+        await session.refresh(organization)
+
+        membership = UserOrganization(
+            user_id=user_id,
+            organization_id=organization.id,
+            role=UserRole.MEMBER,
+        )
+        session.add(membership)
+        await session.commit()
+        await session.refresh(membership)
+
+        organization_event = OrganizationEvent(
+            organization_id=organization.id,
+            event_key=event.event_key,
+            public_data=True,
+            active=True,
+        )
+        session.add(organization_event)
+        await session.commit()
+
+        return {
+            "membership_id": membership.id,
+            "organization_id": organization.id,
+            "team_number": team.team_number,
+            "event_key": event.event_key,
+            "user_id": user_id,
+        }
+
+
+def test_submit_prescout_record_with_scoring_fields(setup_database):
+    context = asyncio.run(_prepare_prescout_context())
+
+    async def override_current_user():
+        return {
+            "id": str(context["user_id"]),
+            "displayName": "Prescout User",
+            "email": "prescout@example.com",
+            "user_org": context["membership_id"],
+        }
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    payload = {
+        "teamNumber": context["team_number"],
+        "matchNumber": 12,
+        "matchLevel": "qm",
+        "notes": None,
+        "al4c": 2,
+        "al3c": 1,
+        "al2c": 0,
+        "al1c": 0,
+        "tl4c": 3,
+        "tl3c": 2,
+        "tl2c": 1,
+        "tl1c": 0,
+        "aProcessor": 1,
+        "tProcessor": 2,
+        "aNet": 0,
+        "tNet": 1,
+        "endgame": Endgame2025.DEEP.value,
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/scout/prescout", json=payload)
+
+    app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["team_number"] == context["team_number"]
+    assert body["event_key"] == context["event_key"]
+    assert body["match_number"] == payload["matchNumber"]
+    assert body["match_level"] == payload["matchLevel"]
+
+    async def _fetch_prescout():
+        async with AsyncSessionLocal() as session:
+            statement = select(Prescout2025).where(
+                Prescout2025.event_key == context["event_key"],
+                Prescout2025.match_number == payload["matchNumber"],
+                Prescout2025.match_level == payload["matchLevel"],
+                Prescout2025.team_number == context["team_number"],
+            )
+            result = await session.execute(statement)
+            return result.scalars().first()
+
+    stored = asyncio.run(_fetch_prescout())
+    assert stored is not None
+    assert stored.al4c == payload["al4c"]
+    assert stored.tl4c == payload["tl4c"]
+    assert stored.aProcessor == payload["aProcessor"]
+    assert stored.endgame == Endgame2025.DEEP


### PR DESCRIPTION
## Summary
- make the Prescout2025 model inherit the 2025 match scoring fields so prescout submissions validate the same schema as match data
- add an alembic migration that backfills the prescout2025 table with the 2025 autonomous, teleop, processor/net, and endgame columns
- add a regression test that submits prescout data with scoring values and asserts they persist

## Testing
- pytest tests/test_prescout_submission.py::test_submit_prescout_record_with_scoring_fields *(fails: missing aiosqlite dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0152ea0b08326869357ecf0b5361b