### PR TITLE
Ensure prescout timestamps use current request time

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -2051,6 +2051,7 @@ async def _submit_record_for_year(
     }
     payload["notes"] = payload.get("notes") or ""
     payload.pop("timestamp", None)
+    payload["timestamp"] = datetime.now()
 
     try:
         typed_record = cast(MatchData, _model_validate(record_model, payload))


### PR DESCRIPTION
## Summary
- remove the prescout timestamp override parameter from the shared submission helper
- always stamp submitted match data records with the server-side current time

## Testing
- pytest tests/test_prescout_submission.py::test_submit_prescout_record_with_scoring_fields *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68f025a31f3c8326a2597c1c71750d55