### PR TITLE
Fix prescout duplicate query for SQLModel models

### DIFF
--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -2075,16 +2075,19 @@ async def _submit_record_for_year(
     except ValidationError as exc:
         _raise_validation_error(f"Invalid {record_label} for this season", exc)
 
-    statement = select(record_model).where(
-        record_model.event_key == getattr(typed_record, "event_key"),
-        record_model.match_number == getattr(typed_record, "match_number"),
-        record_model.match_level == getattr(typed_record, "match_level"),
-        record_model.team_number == getattr(typed_record, "team_number"),
-        record_model.user_id == getattr(typed_record, "user_id"),
-        record_model.organization_id == getattr(typed_record, "organization_id"),
+    statement = (
+        select(record_model)
+        .select_from(record_model.__table__)
+        .where(
+            record_model.event_key == getattr(typed_record, "event_key"),
+            record_model.match_number == getattr(typed_record, "match_number"),
+            record_model.match_level == getattr(typed_record, "match_level"),
+            record_model.team_number == getattr(typed_record, "team_number"),
+            record_model.user_id == getattr(typed_record, "user_id"),
+            record_model.organization_id == getattr(typed_record, "organization_id"),
+        )
     )
-    result = await session.execute(statement)
-    existing_record = result.scalars().first()
+    existing_record = await session.scalar(statement)
     if existing_record is not None:
         if duplicate_behavior == "skip":
             raise MatchAlreadyExistsError(cast(MatchData, existing_record))


### PR DESCRIPTION
## Summary
- update the prescout submission duplicate-check query to build a SQLModel-compatible select statement
- use AsyncSession.scalar to fetch existing records when looking for duplicates

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68f5a740d6fc83269baab2b6c7f3c520