### PR TITLE
Disable asyncpg statement cache for PgBouncer

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -20,7 +20,10 @@ if DATABASE_URL and "+asyncpg" not in DATABASE_URL:
     elif DATABASE_URL.startswith("postgresql://"):
         DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 
-engine: AsyncEngine = create_async_engine(DATABASE_URL)
+engine: AsyncEngine = create_async_engine(
+    DATABASE_URL,
+    connect_args={"statement_cache_size": 0},
+)
 
 async def init_db():
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- disable the asyncpg prepared statement cache so PgBouncer transaction pooling can be used without errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68f6ab998bac8326b41ca3739d2d49d9