### PR TITLE
Disable asyncpg prepared statement cache

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -22,7 +22,10 @@ if DATABASE_URL and "+asyncpg" not in DATABASE_URL:
 
 engine: AsyncEngine = create_async_engine(
     DATABASE_URL,
-    connect_args={"statement_cache_size": 0},
+    connect_args={
+        "statement_cache_size": 0,
+        "prepared_statement_cache_size": 0,
+    },
 )
 
 async def init_db():


### PR DESCRIPTION
## Summary
- disable asyncpg's prepared statement cache when creating the async engine to support PgBouncer transaction mode

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68f6da486d548326a20aec087f111696