### PR TITLE
Enforce site admin authentication for admin endpoints

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -7,9 +7,10 @@ from jose import JWTError, jwt
 from dotenv import load_dotenv
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from uuid import UUID
 
 from db.database import get_session
-from models import AutoAssignUserOrg, User, UserOrganization, UserRole
+from models import AutoAssignUserOrg, SiteAdmins, User, UserOrganization, UserRole
 
 # Load .env file
 load_dotenv()
@@ -105,3 +106,19 @@ async def get_current_user(
     except JWTError as exc:
         logger.exception("JWT decode error while processing authorization header")
         raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+
+async def require_site_admin(
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    try:
+        user_id = UUID(current_user["id"])
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(status_code=403, detail="Site admin access required") from exc
+
+    site_admin = await session.get(SiteAdmins, user_id)
+    if not site_admin:
+        raise HTTPException(status_code=403, detail="Site admin access required")
+
+    return current_user

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select, delete, SQLModel
 from typing import Optional, List, Set
-from auth.dependencies import get_current_user
+from auth.dependencies import require_site_admin
 from db.database import get_session
 from dotenv import load_dotenv
 import requests, os, httpx, asyncio, traceback, aiohttp
@@ -12,7 +12,7 @@ import requests, os, httpx, asyncio, traceback, aiohttp
 router = APIRouter(
     prefix="/admin",
     tags=["Admin"],
-    #dependencies=[Depends(verify_admin)],
+    dependencies=[Depends(require_site_admin)],
 )
 
 from models import (
@@ -43,7 +43,6 @@ class OrganizationResponse(SQLModel):
 @router.post("/organizations/create", response_model=OrganizationResponse)
 async def create_organization(
     command: CreateOrganizationCommand,
-    #user=Depends(get_current_user),
     session: AsyncSession = Depends(get_session)
 ) -> OrganizationResponse:
     #TODO: validate website administrator


### PR DESCRIPTION
## Summary
- add a FastAPI dependency that confirms the authenticated user exists in the `site_admins` table
- require the new dependency across all `/admin` routes to gate them behind site admin access

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'routes')*


------
https://chatgpt.com/codex/tasks/task_e_68f783d3373c8326b9be0717dbc214f9