### PR TITLE
Configure async engines for Supabase PgBouncer

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -19,12 +19,12 @@ load_dotenv()
 # Alembic Config
 config = context.config
 
-# Set sqlalchemy.url from .env (sync driver)
-DB_URL = os.getenv("DB_URL")
-if DB_URL and "asyncpg" in DB_URL:
-    DB_URL = DB_URL.replace("+asyncpg", "+psycopg")  # Use sync psycopg for Alembic
-    print(f"Alembic DB_URL (sync): {DB_URL}")
-config.set_main_option("sqlalchemy.url", DB_URL)
+# Ensure Alembic reuses the application's database engine configuration.
+from app.db.database import get_sync_database_url  # noqa: E402
+
+sync_database_url = get_sync_database_url()
+if sync_database_url:
+    config.set_main_option("sqlalchemy.url", sync_database_url)
 
 # Setup logging from alembic.ini
 if config.config_file_name:

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,37 +1,113 @@
 # app/database.py
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from dotenv import load_dotenv
+from sqlalchemy.engine import URL
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine
-import os
-from dotenv import load_dotenv
 
 # Load environment variables from a .env file if present so that running the
 # application locally works without manually exporting variables.
 load_dotenv()
 
-DATABASE_URL = os.getenv("DB_URL")  # Add to your .env
 
-# Ensure the URL uses SQLAlchemy's async driver. If the environment provides a
-# sync driver or no driver at all, convert it to use ``+asyncpg`` so that the
-# async engine works correctly.
-if DATABASE_URL and "+asyncpg" not in DATABASE_URL:
-    if "+psycopg" in DATABASE_URL:
-        DATABASE_URL = DATABASE_URL.replace("+psycopg", "+asyncpg")
-    elif DATABASE_URL.startswith("postgresql://"):
-        DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+def _normalize_database_url(raw_url: Optional[str]) -> Optional[str]:
+    """Return a SQLAlchemy URL string tailored for async ``asyncpg`` usage.
 
-engine: AsyncEngine = create_async_engine(
+    The Supabase pooled connection lives on port ``6543`` (via PgBouncer in
+    transaction mode). When the provided URL targets a Supabase host we ensure
+    that port is used so the application benefits from the connection pool.
+    Additionally, any PostgreSQL URLs are coerced to the ``+asyncpg`` driver so
+    the async engine works correctly.
+    """
+
+    if not raw_url:
+        return raw_url
+
+    url: URL = make_url(raw_url)
+    drivername = url.drivername
+
+    if drivername.startswith("postgresql") and "+asyncpg" not in drivername:
+        url = url.set(drivername="postgresql+asyncpg")
+
+    if (url.host or "").find("supabase") != -1 and url.port != 6543:
+        url = url.set(port=6543)
+
+    return url.render_as_string(hide_password=False)
+
+
+def _default_connect_args(url: Optional[str]) -> Dict[str, Any]:
+    """Provide driver-appropriate ``connect_args`` for SQLAlchemy engines."""
+
+    if not url:
+        return {}
+
+    drivername = make_url(url).drivername
+    if "asyncpg" in drivername:
+        return {
+            "statement_cache_size": 0,
+            "prepared_statement_cache_size": 0,
+        }
+
+    return {}
+
+
+def create_engine_from_url(
+    database_url: Optional[str],
+    *,
+    connect_args: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
+) -> AsyncEngine:
+    """Create an ``AsyncEngine`` with PgBouncer-safe defaults.
+
+    The returned engine always disables asyncpg's prepared statement caches to
+    avoid ``duplicate prepared statement" errors when PgBouncer operates in
+    transaction pooling mode (the configuration used by Supabase).
+    """
+
+    normalized_url = _normalize_database_url(database_url)
+    default_connect_args = _default_connect_args(normalized_url)
+    merged_connect_args = {**default_connect_args, **(connect_args or {})}
+
+    return create_async_engine(
+        normalized_url,
+        connect_args=merged_connect_args,
+        **kwargs,
+    )
+
+
+DATABASE_URL = _normalize_database_url(os.getenv("DB_URL"))  # Add to your .env
+
+engine: AsyncEngine = create_engine_from_url(
     DATABASE_URL,
-    connect_args={
-        "statement_cache_size": 0,
-        "prepared_statement_cache_size": 0,
-    },
+    pool_pre_ping=True,
 )
 
-async def init_db():
+async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def init_db() -> None:
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
-async def get_session():
-    async with AsyncSession(engine) as session:
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_factory() as session:
         yield session
+
+
+def get_sync_database_url() -> Optional[str]:
+    """Return a sync-compatible URL (``+psycopg``) for Alembic migrations."""
+
+    if not DATABASE_URL:
+        return DATABASE_URL
+
+    url = make_url(DATABASE_URL)
+    if url.drivername.endswith("+asyncpg"):
+        url = url.set(drivername=url.drivername.replace("+asyncpg", "+psycopg"))
+    return url.render_as_string(hide_password=False)

--- a/scripts/match_prediction_daemon.py
+++ b/scripts/match_prediction_daemon.py
@@ -11,9 +11,9 @@ from typing import AsyncIterator, Iterable
 from fastapi import HTTPException
 from sqlalchemy import delete, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.database import engine, init_db
+from app.db.database import async_session_factory, engine, init_db
 from app.models import PredictionQueue
 from app.services.match_prediction import simulate_match_prediction
 
@@ -32,14 +32,11 @@ class QueuedMatch:
     match_number: int
 
 
-session_factory = async_sessionmaker(engine, expire_on_commit=False)
-
-
 @asynccontextmanager
 async def session_scope() -> AsyncIterator[AsyncSession]:
     """Provide a transactional scope around a series of operations."""
 
-    session: AsyncSession = session_factory()
+    session: AsyncSession = async_session_factory()
     try:
         yield session
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os
 import pytest
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
-from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -12,7 +11,9 @@ os.environ.setdefault("DB_URL", "sqlite+aiosqlite://")
 
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
-async_engine = create_async_engine(
+from app.db.database import create_engine_from_url
+
+async_engine = create_engine_from_url(
     TEST_DATABASE_URL,
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,


### PR DESCRIPTION
## Summary
- normalize database URLs to force the Supabase PgBouncer port and asyncpg driver while disabling asyncpg statement caches
- share the application async engine/session factory across background jobs and expose helpers for tests and Alembic
- update Alembic to reuse the application database configuration instead of constructing its own engine

## Testing
- pytest *(fails: existing ModuleNotFoundError for legacy relative imports such as `routes` and `models`)*

------
https://chatgpt.com/codex/tasks/task_e_68f78b0b29308326bbed0fad8b90ff34