### PR TITLE
Configure async sessions to expose SQLModel exec helper

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -88,7 +88,11 @@ engine: AsyncEngine = create_engine_from_url(
     pool_pre_ping=True,
 )
 
-async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+async_session_factory = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
 
 
 async def init_db() -> None:


### PR DESCRIPTION
## Summary
- configure the async session factory to use SQLModel's AsyncSession class so the exec helper is available

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'routes')*


------
https://chatgpt.com/codex/tasks/task_e_68f78ea9c3e883269d4fdd479bacce2b