### PR TITLE
Update match prediction daemon deployment workflow

### DIFF
--- a/.github/workflows/prediction-daemon.yml
+++ b/.github/workflows/prediction-daemon.yml
@@ -1,35 +1,49 @@
-name: Run match prediction daemon
+name: Deploy match prediction daemon
 
 on:
   push:
     branches:
-      - '**'
+      - main
 
 jobs:
   prediction-daemon:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Check out repository
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Launch match prediction daemon
+      - name: Deploy match prediction daemon to DigitalOcean
         env:
-          DB_URL: sqlite+aiosqlite:///./prediction-daemon.db
+          DO_HOST: ${{ secrets.DO_HOST }}
+          DO_USER: ${{ secrets.DO_USER }}
+          DO_PASS: ${{ secrets.DO_PASS }}
         run: |
-          set -euo pipefail
-          python -m scripts.match_prediction_daemon &
-          DAEMON_PID=$!
-          # Allow the daemon to initialize and complete a polling cycle.
-          sleep 310
-          kill $DAEMON_PID || true
-          wait $DAEMON_PID || true
+          sshpass -p "$DO_PASS" ssh -o StrictHostKeyChecking=no $DO_USER@$DO_HOST <<'EOF'
+            set -e
+
+            echo "🔹 Pulling latest code..."
+            cd /opt/Scouting-App-Backend
+            git fetch origin main
+            git reset --hard origin/main
+
+            echo "🔹 Activating virtual environment..."
+            source venv/bin/activate
+
+            echo "🔹 Installing dependencies..."
+            pip install -r requirements.txt --upgrade
+
+            echo "🔹 Restarting match prediction daemon..."
+            screen -S match-prediction -X quit || true
+
+            screen -dmS match-prediction bash -c '
+              cd /opt/Scouting-App-Backend &&
+              source venv/bin/activate &&
+              python -m scripts.match_prediction_daemon
+            '
+
+            echo "✅ Match prediction daemon is running in screen session 'match-prediction'."
+          EOF


### PR DESCRIPTION
## Summary
- connect to the DigitalOcean droplet and refresh the backend repository before running the daemon
- restart the match prediction daemon inside a persistent `screen` session so it keeps polling every five minutes
- trigger the workflow on pushes to `main` to mirror the API deployment pipeline

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f791eb0cc88326814eefe78b17c395