### PR TITLE
Fix admin user retrieval error

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -72,7 +72,7 @@ async def get_all_users(
 ) -> List[AdminUserResponse]:
     statement = select(User)
     result = await session.exec(statement)
-    users = result.scalars().all()
+    users = result.all()
 
     return [
         AdminUserResponse(


### PR DESCRIPTION
## Summary
- adjust the admin user query to use the scalar result correctly when listing users

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7ad1cd85c8326a0e119a8dd4b0a93