### PR TITLE
Disable asyncpg prepared statements for PgBouncer

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -52,6 +52,7 @@ def _default_connect_args(url: Optional[str]) -> Dict[str, Any]:
         return {
             "statement_cache_size": 0,
             "prepared_statement_cache_size": 0,
+            "prepare_threshold": 0,
         }
 
     return {}
@@ -65,9 +66,10 @@ def create_engine_from_url(
 ) -> AsyncEngine:
     """Create an ``AsyncEngine`` with PgBouncer-safe defaults.
 
-    The returned engine always disables asyncpg's prepared statement caches to
-    avoid ``duplicate prepared statement" errors when PgBouncer operates in
-    transaction pooling mode (the configuration used by Supabase).
+    The returned engine always disables asyncpg's prepared statement caches and
+    lowers the ``prepare_threshold`` so that PgBouncer (operating in transaction
+    pooling mode, the configuration used by Supabase) never sees server-side
+    prepared statements.
     """
 
     normalized_url = _normalize_database_url(database_url)


### PR DESCRIPTION
## Summary
- ensure asyncpg connections set prepare_threshold to zero alongside disabled caches
- clarify documentation that PgBouncer-safe engines avoid server-side prepared statements entirely

## Testing
- pytest *(fails: test suite expects package-relative imports; unchanged from main)*

------
https://chatgpt.com/codex/tasks/task_e_68f7be709bf483269591fa72180f612f