### PR TITLE
Add team number to user organization response

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -212,18 +212,22 @@ async def get_current_organization(
     membership_result = await session.exec(membership_statement)
     membership = membership_result.first()
 
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Membership not found")
+
     organization_statement = select(Organization).where(
         Organization.id == membership.organization_id
     )
     organization_result = await session.exec(organization_statement)
     organization: Organization = organization_result.first()
 
-    if membership is None:
-        raise HTTPException(status_code=404, detail="Membership not found")
+    if organization is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
 
     return {
         "organization_id": organization.id,
-        "organization_name": organization.name
+        "organization_name": organization.name,
+        "team_number": organization.team_number,
     }
 
 


### PR DESCRIPTION
## Summary
- return the organization's team number when fetching the current user's organization
- harden the handler by ensuring the membership and organization records exist before accessing them

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'routes')*

------
https://chatgpt.com/codex/tasks/task_e_68fb9d2d7abc832684188917020e697f