### PR TITLE
Add match-specific event image endpoint

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -19,6 +19,7 @@ from services.match_prediction import (
 from services.team_media import (
     EventTeamImagesResponse,
     list_event_team_images,
+    list_match_team_images,
 )
 
 @router.get("/match/{matchLevel}/{matchNumber}", tags=["Scout"])
@@ -133,6 +134,19 @@ async def list_event_images_endpoint(
     user=Depends(get_current_user),
 ):
     return await list_event_team_images(session, user)
+
+
+@router.get(
+    "/match/{matchLevel}/{matchNumber}/images",
+    response_model=list[EventTeamImagesResponse],
+)
+async def list_match_images_endpoint(
+    matchLevel: str,
+    matchNumber: int,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    return await list_match_team_images(session, user, matchLevel, matchNumber)
 
 
 @router.get("s/{year}")

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -16,7 +16,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from models import RobotEventImageLink
 from services.aws import get_s3_client, get_team_images_bucket
-from services.event import get_active_event_key_for_user, get_event_or_404
+from services.event import (
+    get_active_event_key_for_user,
+    get_event_or_404,
+    get_match_or_404,
+)
 from services.team import get_team_or_404
 from sqlmodel import SQLModel
 
@@ -208,4 +212,63 @@ async def list_event_team_images(
     return [
         EventTeamImagesResponse(teamNumber=team_number, images=images)
         for team_number, images in grouped_images.items()
+    ]
+
+
+async def list_match_team_images(
+    session: AsyncSession,
+    user: dict,
+    match_level: str,
+    match_number: int,
+) -> list[EventTeamImagesResponse]:
+    """Return robot images for every team competing in a specific match."""
+
+    event_key = await get_active_event_key_for_user(session, user)
+
+    match = await get_match_or_404(session, event_key, match_number, match_level)
+
+    team_order: list[int] = []
+    seen: set[int] = set()
+    for team_number in (
+        match.red1_id,
+        match.red2_id,
+        match.red3_id,
+        match.blue1_id,
+        match.blue2_id,
+        match.blue3_id,
+    ):
+        if team_number not in seen:
+            seen.add(team_number)
+            team_order.append(team_number)
+
+    if not team_order:
+        return []
+
+    statement = (
+        select(
+            RobotEventImageLink.team_number,
+            RobotEventImageLink.image_url,
+        )
+        .where(
+            RobotEventImageLink.event_key == event_key,
+            RobotEventImageLink.team_number.in_(team_order),
+        )
+        .order_by(
+            RobotEventImageLink.team_number.asc(),
+            RobotEventImageLink.uploaded_at.desc(),
+        )
+    )
+
+    result = await session.execute(statement)
+
+    grouped_images: dict[int, list[str]] = {team_number: [] for team_number in team_order}
+    for team_number, image_url in result.all():
+        grouped_images.setdefault(team_number, []).append(image_url)
+
+    return [
+        EventTeamImagesResponse(
+            teamNumber=team_number,
+            images=grouped_images.get(team_number, []),
+        )
+        for team_number in team_order
     ]

--- a/tests/test_event_images.py
+++ b/tests/test_event_images.py
@@ -21,6 +21,7 @@ from models import (
     Organization,
     OrganizationEvent,
     RobotEventImageLink,
+    MatchSchedule,
     TeamRecord,
     User,
     UserOrganization,
@@ -94,6 +95,24 @@ async def _prepare_event_images_data():
         session.add(org_event)
         await session.commit()
 
+        match = MatchSchedule(
+            event_key=event.event_key,
+            match_number=1,
+            match_level="qm",
+            red1_id=team_one.team_number,
+            red2_id=team_two.team_number,
+            red3_id=team_without_images.team_number,
+            blue1_id=4444,
+            blue2_id=5555,
+            blue3_id=6666,
+        )
+        session.add(match)
+
+        for extra_team in (4444, 5555, 6666):
+            session.add(TeamRecord(teamNumber=extra_team, teamName=f"Team {extra_team}"))
+
+        await session.commit()
+
         image_time = datetime.utcnow()
         images = [
             RobotEventImageLink(
@@ -130,6 +149,8 @@ async def _prepare_event_images_data():
             "team_one": team_one.team_number,
             "team_two": team_two.team_number,
             "team_without_images": team_without_images.team_number,
+            "match_level": match.match_level,
+            "match_number": match.match_number,
         }
 
 
@@ -190,3 +211,38 @@ def test_event_images_endpoint_returns_grouped_links(event_images_client):
     assert "https://cdn.example.com/team1111-other-event.jpg" not in {
         image for entry in payload for image in entry["images"]
     }
+
+
+def test_match_images_endpoint_includes_teams_without_images(event_images_client):
+    client, data = event_images_client
+
+    response = client.get(
+        f"/event/match/{data['match_level']}/{data['match_number']}/images"
+    )
+
+    assert response.status_code == 200
+
+    payload = response.json()
+
+    expected_order = [
+        data["team_one"],
+        data["team_two"],
+        data["team_without_images"],
+        4444,
+        5555,
+        6666,
+    ]
+
+    assert [entry["teamNumber"] for entry in payload] == expected_order
+
+    images_by_team = {entry["teamNumber"]: entry["images"] for entry in payload}
+
+    assert images_by_team[data["team_one"]] == [
+        "https://cdn.example.com/team1111-latest.jpg",
+        "https://cdn.example.com/team1111-older.jpg",
+    ]
+    assert images_by_team[data["team_two"]] == ["https://cdn.example.com/team2222.jpg"]
+    assert images_by_team[data["team_without_images"]] == []
+    assert images_by_team[4444] == []
+    assert images_by_team[5555] == []
+    assert images_by_team[6666] == []


### PR DESCRIPTION
## Summary
- add service helper to gather robot images for teams in a specific match and include teams without uploads
- expose GET /event/match/{matchLevel}/{matchNumber}/images endpoint that returns the grouped images
- expand event image tests to cover match-specific responses and missing images

## Testing
- pytest tests/test_event_images.py

------
https://chatgpt.com/codex/tasks/task_e_68fbaf9896848326b221a135ced9741b