### PR TITLE
Improve FastAPI deployment screen handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           DO_USER: ${{ secrets.DO_USER }}
           DO_PASS: ${{ secrets.DO_PASS }}
         run: |
-          sshpass -p "$DO_PASS" ssh -o StrictHostKeyChecking=no $DO_USER@$DO_HOST << 'EOF'
+          sshpass -p "$DO_PASS" ssh -o StrictHostKeyChecking=no $DO_USER@$DO_HOST <<'REMOTE'
             set -e
             echo "🔹 Pulling latest code..."
             cd /opt/Scouting-App-Backend
@@ -35,16 +35,23 @@ jobs:
             echo "🔹 Installing dependencies..."
             pip install -r requirements.txt --upgrade
 
-            echo "🔹 Restarting FastAPI server..."
-            # stop any existing screen session named api (if exists)
-            screen -S api -X quit || true
+            echo "🔹 Preparing FastAPI server restart..."
+            if screen -list | grep -q '\.api'; then
+              echo "   🔸 Existing 'api' screen session detected. Stopping it..."
+              screen -S api -X quit || true
+              sleep 2
+            else
+              echo "   🔸 No existing 'api' screen session found."
+            fi
 
-            # start a new detached screen running uvicorn
+            echo "🔹 Starting new 'api' screen session..."
             screen -dmS api bash -c '
-              cd /opt/Scouting-App-Backend &&
-              source venv/bin/activate &&
-              uvicorn main:app --app-dir app --host 127.0.0.1 --port 8000 --workers 3
+              set -e
+              cd /opt/Scouting-App-Backend
+              source venv/bin/activate
+              echo "   🔸 Launching uvicorn..."
+              exec uvicorn main:app --app-dir app --host 127.0.0.1 --port 8000 --workers 3
             '
 
             echo "✅ Deployment complete."
-          EOF
+REMOTE


### PR DESCRIPTION
## Summary
- ensure the deployment workflow safely stops any existing `api` screen session before restarting
- wait briefly and start a fresh detached screen that launches uvicorn with the virtual environment activated
- add clearer status output while keeping strict error handling and upgrading requirements during deployment

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fbb446dbac8326919a6769f6712b32