### PR TITLE
Skip persisting matches without TBA score breakdown

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -392,7 +392,14 @@ async def _persist_event_tba_matches(
             continue
 
         alliances = match.get("alliances") or {}
-        breakdown = match.get("score_breakdown") or {}
+        breakdown = match.get("score_breakdown")
+
+        if (
+            not breakdown
+            or not isinstance(breakdown, dict)
+            or not all(breakdown.get(color) for color in ("red", "blue"))
+        ):
+            continue
 
         for color_key, alliance_enum in (("red", Alliance.RED), ("blue", Alliance.BLUE)):
             alliance_info = alliances.get(color_key) or {}


### PR DESCRIPTION
## Summary
- avoid persisting TBA match records when the response lacks score breakdown data
- ensure event match persistence only processes matches with both alliances' breakdowns present

## Testing
- pytest *(fails: existing test suite import errors on main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68fbcfe4b5548326983ccba54f626deb