### PR TITLE
Remove upgrade flag from GitHub Actions requirements installs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
             source venv/bin/activate
 
             echo "🔹 Installing dependencies..."
-            pip install -r requirements.txt --upgrade
+            pip install -r requirements.txt
 
             echo "🔹 Restarting FastAPI server in screen session..."
             if [ -z "$DO_SCREEN_ID" ]; then

--- a/.github/workflows/prediction-daemon.yml
+++ b/.github/workflows/prediction-daemon.yml
@@ -34,7 +34,7 @@ jobs:
             source venv/bin/activate
 
             echo "🔹 Installing dependencies..."
-            pip install -r requirements.txt --upgrade
+            pip install -r requirements.txt
 
             echo "🔹 Restarting match prediction daemon..."
             screen -S match-prediction -X quit || true


### PR DESCRIPTION
## Summary
- remove the `--upgrade` flag from requirements installations in both deployment workflows to avoid implicit dependency upgrades

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fbeac2334c83269d48f7daae493845