### PR TITLE
Add team names to public event teams endpoint

### DIFF
--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -4,11 +4,12 @@ from fastapi import APIRouter, Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from db.database import get_session
-from models import Season, TeamEvent, TeamRecord
+from models import Season, TeamRecord
 from pydantic import BaseModel
 from services.event import (
     EventResponse,
     MatchScheduleResponse,
+    TeamEventResponse,
     get_event_list_or_404,
     get_event_teams_or_404,
     get_match_schedule_or_404,
@@ -67,8 +68,8 @@ async def get_public_seasons(
     return await get_seasons(session)
 
 
-@router.get("/event/teams/{eventCode}", response_model=List[TeamEvent])
+@router.get("/event/teams/{eventCode}", response_model=List[TeamEventResponse])
 async def get_public_event_teams(
     eventCode: str, session: AsyncSession = Depends(get_session)
-) -> List[TeamEvent]:
+) -> List[TeamEventResponse]:
     return await get_event_teams_or_404(session, eventCode)

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -145,6 +145,12 @@ class EventRankingResponse(SQLModel):
     ranking_tiebreaker_2: float
 
 
+class TeamEventResponse(SQLModel):
+    event_key: str
+    team_number: int
+    team_name: Optional[str] = None
+
+
 class EventResponse(SQLModel):
     event_key: str
     event_name: str
@@ -259,17 +265,24 @@ async def get_match_schedule_or_404(session: AsyncSession, eventCode: str) -> Li
     return matches
 
 
-async def get_event_teams_or_404(session: AsyncSession, eventCode: str) -> List[TeamEvent]:
+async def get_event_teams_or_404(
+    session: AsyncSession, eventCode: str
+) -> List[TeamEventResponse]:
     statement = (
-        select(TeamEvent)
+        select(
+            TeamEvent.event_key,
+            TeamEvent.team_number,
+            TeamRecord.team_name,
+        )
+        .join(TeamRecord, TeamRecord.team_number == TeamEvent.team_number, isouter=True)
         .where(TeamEvent.event_key == eventCode)
         .order_by(TeamEvent.team_number)
     )
     result = await session.execute(statement)
-    teams = result.scalars().all()
+    teams = result.mappings().all()
     if not teams:
         raise HTTPException(status_code=404, detail="No teams found for this event")
-    return teams
+    return [TeamEventResponse(**team) for team in teams]
 
 
 async def get_match_data_for_event_or_404(


### PR DESCRIPTION
## Summary
- add a dedicated TeamEventResponse model that includes team names for event teams lookups
- update the public event teams route to return the enriched response shape

## Testing
- pytest *(fails: known metadata duplication error in SQLModel setup for auto_assign_user_org table)*

------
https://chatgpt.com/codex/tasks/task_e_68fe93c69fa48326853bc6078b48c469