### PR TITLE
Queue future predictions on match data updates

### DIFF
--- a/app/routes/organizationadmin.py
+++ b/app/routes/organizationadmin.py
@@ -1032,8 +1032,15 @@ async def get_match_schedule(
     statement = select(MatchSchedule).where(MatchSchedule.event_key == event_key)
     result = await session.exec(statement)
     existing_matches = result.all()
-    existing_match_keys = {
-        (match.match_number, match.match_level)
+    existing_match_assignments = {
+        (match.match_number, match.match_level): (
+            int(match.red1_id),
+            int(match.red2_id),
+            int(match.red3_id),
+            int(match.blue1_id),
+            int(match.blue2_id),
+            int(match.blue3_id),
+        )
         for match in existing_matches
     }
     for match in existing_matches:
@@ -1081,8 +1088,10 @@ async def get_match_schedule(
         )
         session.add(match_record)
 
-        if (match_number, match_level) not in existing_match_keys:
-            matches_for_queue.add((match_number, match_level))
+        match_key = (match_number, match_level)
+        new_assignment = (red1, red2, red3, blue1, blue2, blue3)
+        if existing_match_assignments.get(match_key) != new_assignment:
+            matches_for_queue.add(match_key)
 
     await _enqueue_matches_for_prediction_queue(
         session,

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -2403,6 +2403,13 @@ async def _edit_match_for_year(
         ) from exc
 
     await session.refresh(existing_match)
+
+    await _enqueue_unplayed_matches_for_prediction_queue(
+        session,
+        existing_match,
+        match_model,
+    )
+
     return cast(MatchDataType, existing_match)
 
 async def edit_2025_match(session: AsyncSession, match: MatchData2025, user: User) -> MatchData2025:

--- a/tests/test_prediction_queue_queueing.py
+++ b/tests/test_prediction_queue_queueing.py
@@ -1,55 +1,352 @@
+from datetime import datetime
+import asyncio
+import importlib
+import os
+import sys
+from uuid import uuid4
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+sys.modules.setdefault("auth", importlib.import_module("app.auth"))
+sys.modules.setdefault("db", importlib.import_module("app.db"))
+_models_module = importlib.import_module("app.models")
+sys.modules.setdefault("models", _models_module)
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.models."):
+        sys.modules.setdefault(_name.replace("app.", "", 1), _module)
+_services_module = importlib.import_module("app.services")
+sys.modules.setdefault("services", _services_module)
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.services."):
+        sys.modules.setdefault(_name.replace("app.", "", 1), _module)
+_routes_module = importlib.import_module("app.routes")
+sys.modules.setdefault("routes", _routes_module)
+for _name, _module in list(sys.modules.items()):
+    if _name.startswith("app.routes."):
+        sys.modules.setdefault(_name.replace("app.", "", 1), _module)
+
 import pytest
 from sqlmodel import select
 
-from app.models import FRCEvent, Organization, PredictionQueue
-from app.routes.organizationadmin import _enqueue_matches_for_prediction_queue
+from models import (
+    FRCEvent,
+    MatchData2025,
+    MatchSchedule,
+    Organization,
+    OrganizationEvent,
+    PredictionQueue,
+    Season,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+
+organizationadmin_module = importlib.import_module("app.routes.organizationadmin")
+_enqueue_matches_for_prediction_queue = (
+    organizationadmin_module._enqueue_matches_for_prediction_queue
+)
+from app.services.scout import edit_2025_match
 from tests.conftest import AsyncSessionLocal
 
 
-@pytest.mark.asyncio
-async def test_enqueue_matches_for_prediction_queue_adds_new_matches(setup_database):
-    async with AsyncSessionLocal() as session:
-        event = FRCEvent(event_key="2025queue", event_name="Queue Event", year=2025, week=1)
-        organization = Organization(name="Queue Org", team_number=1234)
-        session.add_all([event, organization])
-        await session.commit()
+def test_enqueue_matches_for_prediction_queue_adds_new_matches(setup_database):
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            event = FRCEvent(event_key="2025queue", event_name="Queue Event", year=2025, week=1)
+            organization = Organization(name="Queue Org", team_number=1234)
+            session.add_all([event, organization])
+            await session.commit()
 
-        await _enqueue_matches_for_prediction_queue(
-            session,
-            event_key=event.event_key,
-            organization_id=organization.id,
-            matches=[(1, "qm"), (2, "qm")],
-        )
-        await session.commit()
-
-        result = await session.execute(
-            select(PredictionQueue).where(
-                PredictionQueue.event_key == event.event_key,
-                PredictionQueue.organization_id == organization.id,
+            await _enqueue_matches_for_prediction_queue(
+                session,
+                event_key=event.event_key,
+                organization_id=organization.id,
+                matches=[(1, "qm"), (2, "qm")],
             )
-        )
-        queued_matches = {
-            (row.match_number, row.match_level)
-            for row in result.scalars().all()
-        }
-        assert queued_matches == {(1, "qm"), (2, "qm")}
+            await session.commit()
 
-        await _enqueue_matches_for_prediction_queue(
-            session,
-            event_key=event.event_key,
-            organization_id=organization.id,
-            matches=[(2, "qm"), (3, "qm")],
-        )
-        await session.commit()
-
-        result = await session.execute(
-            select(PredictionQueue).where(
-                PredictionQueue.event_key == event.event_key,
-                PredictionQueue.organization_id == organization.id,
+            result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == organization.id,
+                )
             )
-        )
-        queued_matches = {
-            (row.match_number, row.match_level)
-            for row in result.scalars().all()
-        }
-        assert queued_matches == {(1, "qm"), (2, "qm"), (3, "qm")}
+            queued_matches = {
+                (row.match_number, row.match_level)
+                for row in result.scalars().all()
+            }
+            assert queued_matches == {(1, "qm"), (2, "qm")}
+
+            await _enqueue_matches_for_prediction_queue(
+                session,
+                event_key=event.event_key,
+                organization_id=organization.id,
+                matches=[(2, "qm"), (3, "qm")],
+            )
+            await session.commit()
+
+            result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == organization.id,
+                )
+            )
+            queued_matches = {
+                (row.match_number, row.match_level)
+                for row in result.scalars().all()
+            }
+            assert queued_matches == {(1, "qm"), (2, "qm"), (3, "qm")}
+
+    asyncio.run(_run_test())
+
+
+def test_edit_match_enqueues_unplayed_matches(setup_database):
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            season = Season(id=9401, year=2025, name="Queue Season")
+            event = FRCEvent(
+                event_key="2025editqueue",
+                event_name="Queue Edit Event",
+                short_name="Queue Edit",
+                year=2025,
+                week=1,
+            )
+            organization = Organization(name="Queue Org", team_number=4321)
+            user_id = uuid4()
+            now = datetime.utcnow()
+            user = User(
+                id=user_id,
+                email="queue@example.com",
+                auth_provider="discord",
+                display_name="Queue User",
+                logged_in_user_org=None,
+                created_at=now,
+                updated_at=now,
+            )
+            team_records = [
+                TeamRecord(teamNumber=4321, teamName="Queue Team"),
+                TeamRecord(teamNumber=1111, teamName="Allied Team 1"),
+                TeamRecord(teamNumber=2222, teamName="Allied Team 2"),
+                TeamRecord(teamNumber=3333, teamName="Opponent Team 1"),
+                TeamRecord(teamNumber=4444, teamName="Opponent Team 2"),
+                TeamRecord(teamNumber=5555, teamName="Opponent Team 3"),
+            ]
+
+            session.add_all([season, event, organization, user, *team_records])
+            await session.commit()
+            await session.refresh(organization)
+
+            membership = UserOrganization(
+                user_id=user_id,
+                organization_id=organization.id,
+                role=UserRole.ADMIN,
+            )
+            session.add(membership)
+            await session.commit()
+            await session.refresh(membership)
+
+            schedule_entries = [
+                MatchSchedule(
+                    event_key=event.event_key,
+                    match_number=1,
+                    match_level="qm",
+                    red1_id=4321,
+                    red2_id=1111,
+                    red3_id=2222,
+                    blue1_id=3333,
+                    blue2_id=4444,
+                    blue3_id=5555,
+                ),
+                MatchSchedule(
+                    event_key=event.event_key,
+                    match_number=2,
+                    match_level="qm",
+                    red1_id=4321,
+                    red2_id=1111,
+                    red3_id=2222,
+                    blue1_id=3333,
+                    blue2_id=4444,
+                    blue3_id=5555,
+                ),
+            ]
+            session.add_all(schedule_entries)
+            await session.commit()
+
+            original_match = MatchData2025(
+                season=season.id,
+                team_number=4321,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                notes="Original",
+            )
+            session.add(original_match)
+            await session.commit()
+
+            updated_match = MatchData2025(
+                season=season.id,
+                team_number=4321,
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                user_id=user_id,
+                organization_id=organization.id,
+                notes="Updated",
+            )
+
+            user_payload = {"id": str(user_id), "user_org": membership.id}
+            await edit_2025_match(session, updated_match, user_payload)
+
+            result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == organization.id,
+                )
+            )
+            queued_matches = {
+                (row.match_number, row.match_level)
+                for row in result.scalars().all()
+            }
+            assert queued_matches == {(2, "qm")}
+
+    asyncio.run(_run_test())
+
+
+def test_match_schedule_sync_queues_modified_matches(monkeypatch, setup_database):
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            event = FRCEvent(
+                event_key="2025queuesync",
+                event_name="Queue Sync Event",
+                short_name="Queue Sync",
+                year=2025,
+                week=1,
+            )
+            organization = Organization(name="Sync Org", team_number=9876)
+            user_id = uuid4()
+            now = datetime.utcnow()
+            user = User(
+                id=user_id,
+                email="sync@example.com",
+                auth_provider="discord",
+                display_name="Sync User",
+                logged_in_user_org=None,
+                created_at=now,
+                updated_at=now,
+            )
+            team_records = [
+                TeamRecord(teamNumber=9876, teamName="Sync Team"),
+                TeamRecord(teamNumber=1010, teamName="Partner 1"),
+                TeamRecord(teamNumber=2020, teamName="Partner 2"),
+                TeamRecord(teamNumber=3030, teamName="Opponent 1"),
+                TeamRecord(teamNumber=4040, teamName="Opponent 2"),
+                TeamRecord(teamNumber=5050, teamName="Opponent 3"),
+                TeamRecord(teamNumber=6060, teamName="Opponent 4"),
+            ]
+
+            session.add_all([event, organization, user, *team_records])
+            await session.commit()
+            await session.refresh(organization)
+
+            membership = UserOrganization(
+                user_id=user_id,
+                organization_id=organization.id,
+                role=UserRole.ADMIN,
+            )
+            session.add(membership)
+            await session.commit()
+            await session.refresh(membership)
+
+            organization_event = OrganizationEvent(
+                organization_id=organization.id,
+                event_key=event.event_key,
+                public_data=True,
+                active=True,
+            )
+            session.add(organization_event)
+            await session.commit()
+
+            existing_match = MatchSchedule(
+                event_key=event.event_key,
+                match_number=1,
+                match_level="qm",
+                red1_id=9876,
+                red2_id=1010,
+                red3_id=2020,
+                blue1_id=3030,
+                blue2_id=4040,
+                blue3_id=5050,
+            )
+            session.add(existing_match)
+            await session.commit()
+
+            new_schedule_payload = [
+                {
+                    "comp_level": "qm",
+                    "match_number": 1,
+                    "alliances": {
+                        "red": {
+                            "team_keys": [
+                                "frc9876",
+                                "frc1010",
+                                "frc2020",
+                            ]
+                        },
+                        "blue": {
+                            "team_keys": [
+                                "frc3030",
+                                "frc4040",
+                                "frc6060",
+                            ]
+                        },
+                    },
+                }
+            ]
+
+            class MockResponse:
+                def __init__(self, payload):
+                    self._payload = payload
+
+                def json(self):
+                    return self._payload
+
+            class MockAsyncClient:
+                def __init__(self, payload):
+                    self._payload = payload
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    return False
+
+                async def get(self, url, headers=None):
+                    return MockResponse(self._payload)
+
+            monkeypatch.setattr(
+                organizationadmin_module.httpx,
+                "AsyncClient",
+                lambda *args, **kwargs: MockAsyncClient(new_schedule_payload),
+            )
+
+            user_payload = {"id": str(user_id), "user_org": membership.id}
+            await organizationadmin_module.get_match_schedule(
+                user=user_payload, session=session
+            )
+
+            result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == organization.id,
+                )
+            )
+            queued_matches = {
+                (row.match_number, row.match_level)
+                for row in result.scalars().all()
+            }
+            assert queued_matches == {(1, "qm")}
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- enqueue a team's remaining matches for predictions whenever match data is edited
- enqueue newly added or modified schedule matches when syncing event schedules
- add tests covering match edits and schedule updates queuing prediction jobs

## Testing
- pytest tests/test_prediction_queue_queueing.py

------
https://chatgpt.com/codex/tasks/task_e_68feb3111c1c8326a97874a6e338b827