### PR TITLE
Set DigitalOcean deployment to use screen 1349

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           DO_HOST: ${{ secrets.DO_HOST }}
           DO_USER: ${{ secrets.DO_USER }}
           DO_PASS: ${{ secrets.DO_PASS }}
-          DO_SCREEN_ID: ${{ secrets.DO_SCREEN_ID }}
+          DO_SCREEN_ID: "1349"
         run: |
           sshpass -p "$DO_PASS" ssh -o StrictHostKeyChecking=no $DO_USER@$DO_HOST << 'EOF'
             set -e


### PR DESCRIPTION
## Summary
- configure the DigitalOcean deployment workflow to always target screen session 1349

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ff8c7267b88326ad14c82e7bc421b7