### PR TITLE
Ensure asyncpg URLs disable statement caches

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -34,9 +34,18 @@ def _normalize_database_url(raw_url: Optional[str]) -> Optional[str]:
 
     if drivername.startswith("postgresql") and "+asyncpg" not in drivername:
         url = url.set(drivername="postgresql+asyncpg")
+        drivername = url.drivername
 
     if (url.host or "").find("supabase") != -1 and url.port != 6543:
         url = url.set(port=6543)
+
+    if "asyncpg" in drivername:
+        url = url.update_query_dict(
+            {
+                "statement_cache_size": "0",
+                "prepared_statement_cache_size": "0",
+            }
+        )
 
     return url.render_as_string(hide_password=False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,19 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
 
 import pytest
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+APP_PATH = PROJECT_ROOT / "app"
+
+if str(APP_PATH) not in sys.path:
+    sys.path.insert(0, str(APP_PATH))
 
 os.environ.setdefault("DB_URL", "sqlite+aiosqlite://")
 
@@ -40,6 +48,10 @@ async def _drop_tables():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_database():
+    if os.getenv("SKIP_DB_SETUP") == "1":
+        yield
+        return
+
     from app.main import app
     from app.db.database import get_session
 

--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+import sys
+
+os.environ.setdefault("SKIP_DB_SETUP", "1")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_ANON_KEY", "anon")
+
+APP_PATH = Path(__file__).resolve().parents[1] / "app"
+
+if str(APP_PATH) not in sys.path:
+    sys.path.insert(0, str(APP_PATH))
+
+from sqlalchemy.engine.url import make_url
+
+from app.db import database
+
+
+def test_normalize_asyncpg_url_enforces_cache_settings():
+    normalized = database._normalize_database_url(
+        "postgresql://user:pass@host/database"
+    )
+
+    url = make_url(normalized)
+
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.query["statement_cache_size"] == "0"
+    assert url.query["prepared_statement_cache_size"] == "0"
+
+
+def test_normalize_asyncpg_url_overrides_existing_cache_settings():
+    normalized = database._normalize_database_url(
+        "postgresql://user:pass@host/database?statement_cache_size=25"
+    )
+
+    url = make_url(normalized)
+
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.query["statement_cache_size"] == "0"
+    assert url.query["prepared_statement_cache_size"] == "0"


### PR DESCRIPTION
## Summary
- force asyncpg URLs produced by `_normalize_database_url` to disable prepared/statement caches so PgBouncer connections avoid duplicate prepared statement errors
- update the pytest database fixture to ensure the `db` package is importable and allow skipping heavy DB setup when not required
- add a focused unit test module covering the asyncpg URL normalization behaviour

## Testing
- `pytest tests/test_database_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68ff91cc2cac8326a3de2ea7dbc98a4b