### PR TITLE
Fix import paths in FastAPI entrypoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,12 +4,12 @@ import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.db.database import init_db
-from app.services.match_prediction_daemon import (
+from .db.database import init_db
+from .services.match_prediction_daemon import (
     SLEEP_INTERVAL_SECONDS,
     process_prediction_queue,
 )
-from routes import (
+from .routes import (
     admin,
     analytics,
     event,


### PR DESCRIPTION
## Summary
- switch the FastAPI main module to use relative imports so it can be imported when running under Uvicorn

## Testing
- pytest *(fails: Table 'auto_assign_user_org' is already defined for this MetaData instance when loading models)*

------
https://chatgpt.com/codex/tasks/task_e_68ff94bd4d288326a59bbfde6e648d6c