### PR TITLE
Disable asyncpg prepared statements behind PgBouncer

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -52,6 +52,12 @@ def _default_connect_args(url: Optional[str]) -> Dict[str, Any]:
         return {
             "statement_cache_size": 0,
             "prepared_statement_cache_size": 0,
+            # ``prepare_threshold`` ensures asyncpg never promotes a statement to a
+            # prepared statement even if it is executed repeatedly.  PgBouncer in
+            # transaction/statement pooling mode cannot safely work with prepared
+            # statements because backend connections are swapped between clients
+            # transparently, so we disable the optimisation entirely.
+            "prepare_threshold": 0,
         }
 
     return {}


### PR DESCRIPTION
## Summary
- ensure asyncpg connections never promote queries to prepared statements when going through PgBouncer
- document why the new connect argument is required for Supabase/transaction-pooled Postgres instances

## Testing
- pytest *(fails: existing metadata definitions in the current test suite setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ff96ce09548326823d88bfdddd6860