### PR TITLE
Refactor imports to use app package roots

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -9,8 +9,8 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from uuid import UUID
 
-from db.database import get_session
-from models import AutoAssignUserOrg, SiteAdmins, User, UserOrganization, UserRole
+from app.db.database import get_session
+from app.models import AutoAssignUserOrg, SiteAdmins, User, UserOrganization, UserRole
 
 # Load .env file
 load_dotenv()

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from app.services.match_prediction_daemon import (
     SLEEP_INTERVAL_SECONDS,
     process_prediction_queue,
 )
-from routes import (
+from app.routes import (
     admin,
     analytics,
     event,

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -6,7 +6,7 @@ from sqlmodel import select, delete, SQLModel
 from typing import Optional, List, Set
 from datetime import datetime
 from auth.dependencies import require_site_admin
-from db.database import get_session
+from app.db.database import get_session
 from dotenv import load_dotenv
 import requests, os, httpx, asyncio, traceback, aiohttp
 
@@ -17,7 +17,7 @@ router = APIRouter(
     dependencies=[Depends(require_site_admin)],
 )
 
-from models import (
+from app.models import (
     Organization,
     OrganizationFeatureSettings,
     TeamRecord,

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
-from db.database import get_session
-from services.analytics.event_summary import (
+from app.db.database import get_session
+from app.services.analytics.event_summary import (
     EventTeamZScoreResponse,
     TeamEventDetailedSummary,
     TeamHeadToHeadStatistics,

--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -1,22 +1,22 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 from auth.dependencies import get_current_user
-from db.database import get_session
+from app.db.database import get_session
 from typing import Any, Dict, List, Optional, Union
 
-from models import Organization, FRCEvent
+from app.models import Organization, FRCEvent
 
 router = APIRouter(
     prefix="/event",
     tags=["Event"],
 )
 
-from services.event import *
-from services.match_prediction import (
+from app.services.event import *
+from app.services.match_prediction import (
     get_match_prediction_for_user_organization,
     simulate_match_prediction,
 )
-from services.team_media import (
+from app.services.team_media import (
     EventTeamImagesResponse,
     list_event_team_images,
     list_match_team_images,

--- a/app/routes/organizationadmin.py
+++ b/app/routes/organizationadmin.py
@@ -3,7 +3,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import SQLModel, delete, select, update
 from datetime import datetime
 from auth.dependencies import get_current_user
-from db.database import get_session
+from app.db.database import get_session
 from dotenv import load_dotenv
 import os, httpx
 import csv
@@ -139,7 +139,7 @@ router = APIRouter(
     tags=["Organization"]
 )
 
-from models import (
+from app.models import (
     DataValidation,
     FRCEvent,
     MatchData2025,
@@ -160,8 +160,8 @@ from models import (
     UserOrganization,
     Endgame2025,
 )
-from models.user_organization import UserRole
-from services.event import (
+from app.models.user_organization import UserRole
+from app.services.event import (
     MatchExportRequest,
     MatchExportType,
     get_active_event_key_for_user,

--- a/app/routes/picklist.py
+++ b/app/routes/picklist.py
@@ -10,14 +10,14 @@ from sqlmodel import Field, SQLModel, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
-from db.database import get_session
-from models import PickList, PickListRank
-from services.event import (
+from app.db.database import get_session
+from app.models import PickList, PickListRank
+from app.services.event import (
     get_active_event_key_for_user,
     get_event_or_404,
     require_lead_or_admin_membership,
 )
-from services.picklist import (
+from app.services.picklist import (
     fetch_picklist_generators,
     fetch_picklists_for_event,
     fetch_ranks_for_picklists,
@@ -25,7 +25,7 @@ from services.picklist import (
     get_picklist_generator_by_id,
     get_picklist_generator_model_for_year,
 )
-from services.season import get_season_by_year_or_404
+from app.services.season import get_season_by_year_or_404
 
 
 router = APIRouter(

--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -3,10 +3,10 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from db.database import get_session
-from models import Season, TeamRecord
+from app.db.database import get_session
+from app.models import Season, TeamRecord
 from pydantic import BaseModel
-from services.event import (
+from app.services.event import (
     EventResponse,
     MatchScheduleResponse,
     TeamEventResponse,
@@ -14,8 +14,8 @@ from services.event import (
     get_event_teams_or_404,
     get_match_schedule_or_404,
 )
-from services.season import get_seasons
-from services.team import get_team_records_page
+from app.services.season import get_seasons
+from app.services.team import get_team_records_page
 
 
 class PaginationMeta(BaseModel):

--- a/app/routes/scout.py
+++ b/app/routes/scout.py
@@ -9,11 +9,11 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
-from db.database import get_session
+from app.db.database import get_session
 
-from models import DataValidation, MatchData, PitScout, Season, SuperScoutData, ValidationStatus
-from services.event import MATCH_DATA_MODELS_BY_YEAR
-from services.scout import PIT_SCOUT_MODELS_BY_YEAR
+from app.models import DataValidation, MatchData, PitScout, Season, SuperScoutData, ValidationStatus
+from app.services.event import MATCH_DATA_MODELS_BY_YEAR
+from app.services.scout import PIT_SCOUT_MODELS_BY_YEAR
 
 router = APIRouter(
     prefix="/scout",
@@ -22,7 +22,7 @@ router = APIRouter(
 
 logger = logging.getLogger(__name__)
 
-from services.scout import (
+from app.services.scout import (
     DataValidationFilterRequest,
     DataValidationUpdateRequest,
     ScoutMatchFilterRequest,

--- a/app/routes/season.py
+++ b/app/routes/season.py
@@ -3,9 +3,9 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from db.database import get_session
-from models import Season
-from services.season import get_seasons
+from app.db.database import get_session
+from app.models import Season
+from app.services.season import get_seasons
 
 router = APIRouter(tags=["Season"])
 

--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -2,12 +2,12 @@ from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
-from db.database import get_session
-from services.team import (
+from app.db.database import get_session
+from app.services.team import (
     get_match_data_for_team_at_active_event,
     get_team_or_404,
 )
-from services.team_media import (
+from app.services.team_media import (
     RobotEventImageLinkResponse,
     list_team_images,
     upload_team_image,

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -7,10 +7,10 @@ from sqlmodel import Field, SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from auth.dependencies import get_current_user
-from db.database import get_session
-from models import Organization, SiteAdmins, UserOrganization, User
-from models.user_organization import UserRole
-from services.event import get_active_event_key_for_user
+from app.db.database import get_session
+from app.models import Organization, SiteAdmins, UserOrganization, User
+from app.models.user_organization import UserRole
+from app.services.event import get_active_event_key_for_user
 
 router = APIRouter()
 

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 from sqlmodel import Field, SQLModel, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import (
+from app.models import (
     MatchSchedule,
     MatchData2025,
     MatchData2026,
@@ -29,13 +29,13 @@ from models import (
     EventRankings,
     StatboticsData,
 )
-from services.scoring import (
+from app.services.scoring import (
     calculate_endgame_points,
     extract_field_value,
     resolve_endgame_points_mapping,
     resolve_weight_mapping,
 )
-from services.season import get_season_by_year_or_404
+from app.services.season import get_season_by_year_or_404
 
 
 async def get_scouting_alliance_organization_ids(

--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import (
+from app.models import (
     MatchData,
     MatchPredictions2025,
     Organization,
@@ -23,7 +23,7 @@ from models import (
     StatboticsData,
     UserOrganization,
 )
-from services.event import (
+from app.services.event import (
     DEFAULT_AUTO_WEIGHTS,
     DEFAULT_ENDGAME_POINTS,
     DEFAULT_TELEOP_WEIGHTS,
@@ -37,7 +37,7 @@ from services.event import (
     get_scouting_alliance_organization_ids,
     update_statbotics_data_for_event,
 )
-from services.scoring import (
+from app.services.scoring import (
     calculate_endgame_points,
     calculate_phase_points,
     resolve_endgame_points_mapping,

--- a/app/services/match_prediction_daemon.py
+++ b/app/services/match_prediction_daemon.py
@@ -12,9 +12,9 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.database import async_session_factory
-from models import PredictionQueue
-from services.match_prediction import simulate_match_prediction
+from app.db.database import async_session_factory
+from app.models import PredictionQueue
+from app.services.match_prediction import simulate_match_prediction
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")

--- a/app/services/picklist.py
+++ b/app/services/picklist.py
@@ -8,13 +8,13 @@ from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import (
+from app.models import (
     PickList,
     PickListGenerator,
     PickListGenerator2025,
     PickListRank,
 )
-from services.analytics.event_summary import get_team_event_z_scores
+from app.services.analytics.event_summary import get_team_event_z_scores
 
 
 PICKLIST_GENERATOR_MODELS_BY_YEAR: Dict[int, Type[PickListGenerator]] = {

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -29,7 +29,7 @@ from sqlmodel import SQLModel, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from uuid import UUID
 
-from models import (
+from app.models import (
     Alliance,
     DataValidation,
     MatchData,
@@ -49,15 +49,15 @@ from models import (
     UserOrganization,
     ValidationStatus,
 )
-from models.tba_match_data_2025 import Endgame2025 as TBAEndgame2025
+from app.models.tba_match_data_2025 import Endgame2025 as TBAEndgame2025
 
-from services.event import (
+from app.services.event import (
     MATCH_DATA_MODELS_BY_YEAR,
     get_active_event_key_for_user,
     get_event_or_404,
     get_scouting_alliance_organization_ids,
 )
-from services.season import get_season_by_year_or_404
+from app.services.season import get_season_by_year_or_404
 
 TBA_API_BASE_URL = "https://www.thebluealliance.com/api/v3"
 TBA_API_KEY_ENV_VAR = "TBA_API_KEY"

--- a/app/services/season.py
+++ b/app/services/season.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import Season
+from app.models import Season
 
 
 async def get_seasons(session: AsyncSession) -> List[Season]:

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -6,8 +6,8 @@ from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import TeamRecord, UserOrganization
-from services.event import (
+from app.models import TeamRecord, UserOrganization
+from app.services.event import (
     MATCH_DATA_MODELS_BY_YEAR,
     get_active_event_key_for_user,
     get_event_or_404,

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -14,14 +14,14 @@ from pydantic import BaseModel, ConfigDict
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from models import RobotEventImageLink
-from services.aws import get_s3_client, get_team_images_bucket
-from services.event import (
+from app.models import RobotEventImageLink
+from app.services.aws import get_s3_client, get_team_images_bucket
+from app.services.event import (
     get_active_event_key_for_user,
     get_event_or_404,
     get_match_or_404,
 )
-from services.team import get_team_or_404
+from app.services.team import get_team_or_404
 from sqlmodel import SQLModel
 
 ALLOWED_IMAGE_EXTENSIONS: Iterable[str] = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}


### PR DESCRIPTION
## Summary
- update authentication dependencies and main module imports to use the app package prefix
- refactor all route modules to reference app.* paths for database, models, and services
- adjust service layer imports to consistently use fully-qualified app package paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffa400c8bc8326968c1caa4ddbd7e4