### PR TITLE
Configure local error logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+from logging.handlers import RotatingFileHandler
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -21,6 +23,62 @@ from app.routes import (
     team,
     user,
 )
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_DIRECTORY = os.getenv("LOG_DIRECTORY", "logs")
+LOG_FILE_NAME = os.getenv("LOG_FILE_NAME", "server.log")
+ERROR_LOG_FILE_NAME = os.getenv("ERROR_LOG_FILE_NAME", "error.log")
+
+
+def configure_logging() -> None:
+    """Configure application logging.
+
+    The configuration ensures that log messages continue to be emitted to the
+    console (matching the existing behaviour) while also writing all messages to
+    a rotating file log and capturing errors in a dedicated rotating error log.
+    The handler setup is only performed once to avoid duplicate log entries
+    when the module is imported multiple times (such as when running under a
+    reloader).
+    """
+
+    root_logger = logging.getLogger()
+    already_configured = any(
+        getattr(handler, "_scouting_app_logging", False)
+        for handler in root_logger.handlers
+    )
+    if already_configured:
+        return
+
+    os.makedirs(LOG_DIRECTORY, exist_ok=True)
+
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    formatter = logging.Formatter(log_format)
+
+    root_logger.setLevel(LOG_LEVEL)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    stream_handler._scouting_app_logging = True  # type: ignore[attr-defined]
+    root_logger.addHandler(stream_handler)
+
+    log_path = os.path.join(LOG_DIRECTORY, LOG_FILE_NAME)
+    file_handler = RotatingFileHandler(log_path, maxBytes=10**6, backupCount=5)
+    file_handler.setLevel(LOG_LEVEL)
+    file_handler.setFormatter(formatter)
+    file_handler._scouting_app_logging = True  # type: ignore[attr-defined]
+    root_logger.addHandler(file_handler)
+
+    error_log_path = os.path.join(LOG_DIRECTORY, ERROR_LOG_FILE_NAME)
+    error_handler = RotatingFileHandler(
+        error_log_path, maxBytes=10**6, backupCount=5
+    )
+    error_handler.setLevel(logging.ERROR)
+    error_handler.setFormatter(formatter)
+    error_handler._scouting_app_logging = True  # type: ignore[attr-defined]
+    root_logger.addHandler(error_handler)
+
+
+configure_logging()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- configure FastAPI application's logging to write to local rotating log files
- add a dedicated rotating error log alongside the console stream handler

## Testing
- pytest *(fails: existing test failures unrelated to logging configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa7a275a08326b4961b1e53ec4e0e