### PR TITLE
Ensure match prediction daemon runs once across workers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.db.database import init_db
 from app.services.match_prediction_daemon import (
     SLEEP_INTERVAL_SECONDS,
+    acquire_prediction_daemon_lock,
     process_prediction_queue,
+    release_prediction_daemon_lock,
 )
 from app.routes import (
     admin,
@@ -120,24 +122,44 @@ app.include_router(public.router)
 
 async def run_prediction_daemon() -> None:
     logger.info("Starting match prediction daemon")
-    while True:
-        try:
-            await process_prediction_queue()
-        except Exception:
-            logger.exception("Unhandled error in prediction daemon loop")
-        logger.info("Sleeping for %d seconds.", SLEEP_INTERVAL_SECONDS)
-        await asyncio.sleep(SLEEP_INTERVAL_SECONDS)
+    try:
+        while True:
+            try:
+                await process_prediction_queue()
+            except Exception:
+                logger.exception("Unhandled error in prediction daemon loop")
+            logger.info("Sleeping for %d seconds.", SLEEP_INTERVAL_SECONDS)
+            await asyncio.sleep(SLEEP_INTERVAL_SECONDS)
+    except asyncio.CancelledError:
+        logger.info("Match prediction daemon cancelled; shutting down.")
+        raise
 
 
 @app.on_event("startup")
 async def on_startup() -> None:
     await init_db()
-    app.state.prediction_daemon_task = asyncio.create_task(run_prediction_daemon())
+    should_run, lock_connection = await acquire_prediction_daemon_lock()
+    app.state.prediction_daemon_lock = lock_connection
+    if should_run:
+        app.state.prediction_daemon_task = asyncio.create_task(run_prediction_daemon())
+    else:
+        app.state.prediction_daemon_task = None
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
     logger.info("FastAPI application shutting down.")
+    task = getattr(app.state, "prediction_daemon_task", None)
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    lock_connection = getattr(app.state, "prediction_daemon_lock", None)
+    if lock_connection is not None:
+        await release_prediction_daemon_lock(lock_connection)
 
 
 @app.get("/ping")

--- a/app/services/match_prediction_daemon.py
+++ b/app/services/match_prediction_daemon.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import AsyncIterator, Iterable
+from typing import AsyncIterator, Iterable, Optional, Tuple
 
 from fastapi import HTTPException
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 
-from app.db.database import async_session_factory
+from app.db.database import async_session_factory, engine
 from app.models import PredictionQueue
 from app.services.match_prediction import simulate_match_prediction
 
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
 SLEEP_INTERVAL_SECONDS = 5 * 60
+_DAEMON_LOCK_ID = 42_004_200  # Arbitrary constant that uniquely identifies the daemon lock.
 
 
 @dataclass(frozen=True)
@@ -70,6 +71,59 @@ async def _mark_match_complete(session: AsyncSession, match: QueuedMatch) -> Non
         )
     )
     await session.commit()
+
+
+async def acquire_prediction_daemon_lock() -> Tuple[bool, Optional[AsyncConnection]]:
+    """Attempt to acquire a database-backed lock for the daemon.
+
+    The lock uses PostgreSQL advisory locks when available so that only a single
+    worker process runs the prediction daemon. If the database backend does not
+    support advisory locks the daemon is allowed to run without coordination.
+    """
+
+    connection = await engine.connect()
+    dialect_name = connection.dialect.name
+
+    if not dialect_name.startswith("postgresql"):
+        logger.info(
+            "Database dialect '%s' does not support advisory locks; running prediction daemon without coordination.",
+            dialect_name,
+        )
+        await connection.close()
+        return True, None
+
+    try:
+        result = await connection.execute(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": _DAEMON_LOCK_ID},
+        )
+        acquired = bool(result.scalar())
+        if acquired:
+            logger.info("Acquired match prediction daemon advisory lock.")
+            return True, connection
+
+        logger.info(
+            "Another worker already holds the match prediction daemon advisory lock; skipping daemon start."
+        )
+    except SQLAlchemyError:
+        logger.exception("Failed to acquire match prediction daemon lock; daemon will not be started in this worker.")
+
+    await connection.close()
+    return False, None
+
+
+async def release_prediction_daemon_lock(connection: AsyncConnection) -> None:
+    """Release the advisory lock acquired for the daemon."""
+
+    try:
+        await connection.execute(
+            text("SELECT pg_advisory_unlock(:lock_id)"),
+            {"lock_id": _DAEMON_LOCK_ID},
+        )
+    except SQLAlchemyError:
+        logger.exception("Failed to release match prediction daemon advisory lock.")
+    finally:
+        await connection.close()
 
 
 async def process_prediction_queue() -> bool:
@@ -132,7 +186,9 @@ async def process_prediction_queue() -> bool:
 
 
 __all__ = [
+    "acquire_prediction_daemon_lock",
     "QueuedMatch",
+    "release_prediction_daemon_lock",
     "SLEEP_INTERVAL_SECONDS",
     "process_prediction_queue",
     "session_scope",


### PR DESCRIPTION
## Summary
- guard the match prediction daemon with a database-backed advisory lock so only one worker runs it
- cancel the background task and release any acquired lock during application shutdown

## Testing
- pytest *(fails: existing suite lacks async test plugin and hits sqlite unique constraints in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa950e9108326b69c294f93433138