### PR TITLE
Add endpoint to list match predictions for active event

### DIFF
--- a/app/routes/event.py
+++ b/app/routes/event.py
@@ -14,6 +14,7 @@ router = APIRouter(
 from app.services.event import *
 from app.services.match_prediction import (
     get_match_prediction_for_user_organization,
+    list_match_predictions_for_event,
     simulate_match_prediction,
 )
 from app.services.team_media import (
@@ -65,6 +66,14 @@ async def run_match_simulation(
 ):
     event_code = await get_active_event_key_for_user(session, user)
     return await simulate_match_prediction(session, event_code, matchLevel, matchNumber)
+
+
+@router.get("/matches/simulation", tags=["Scout"])
+async def list_match_simulations(
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+):
+    return await list_match_predictions_for_event(session, user)
 
 
 @router.get("/matches")

--- a/app/services/match_prediction.py
+++ b/app/services/match_prediction.py
@@ -686,6 +686,41 @@ async def get_match_prediction_for_user_organization(
     return predictions[0]
 
 
+async def list_match_predictions_for_event(
+    session: AsyncSession,
+    user: Any,
+):
+    """Return all stored match predictions for the active event."""
+
+    user_payload = _normalize_user_payload(user)
+
+    event_key = await get_active_event_key_for_user(session, user_payload)
+    event = await get_event_or_404(session, event_key)
+    membership = await _get_user_membership_or_404(session, user_payload)
+
+    prediction_model = MATCH_PREDICTION_MODELS_BY_YEAR.get(event.year)
+    if prediction_model is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Match predictions are not available for this event year",
+        )
+
+    statement = (
+        select(prediction_model)
+        .where(
+            prediction_model.event_key == event_key,
+            prediction_model.organization_id == membership.organization_id,
+        )
+        .order_by(
+            prediction_model.match_level,
+            prediction_model.match_number,
+        )
+    )
+
+    result = await session.execute(statement)
+    return list(result.scalars().all())
+
+
 async def simulate_match_prediction(
     session: AsyncSession,
     event_code: str,


### PR DESCRIPTION
## Summary
- add a service helper to collect all stored match predictions for the active event and organization
- expose the data through a new GET /event/matches/simulation endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffb662b96c8326af82e4ea24663901