### PR TITLE
Order queued matches for prediction daemon

### DIFF
--- a/app/services/match_prediction_daemon.py
+++ b/app/services/match_prediction_daemon.py
@@ -49,7 +49,9 @@ async def _load_queued_matches(session: AsyncSession) -> Iterable[QueuedMatch]:
             PredictionQueue.event_key,
             PredictionQueue.match_level,
             PredictionQueue.match_number,
-        ).distinct()
+        )
+        .distinct()
+        .order_by(PredictionQueue.match_number.asc())
     )
     rows = result.all()
     return [


### PR DESCRIPTION
## Summary
- ensure the match prediction daemon loads queued matches sorted by ascending match number

## Testing
- pytest *(fails: numerous pre-existing test failures in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe1d4017083268eb466382835de8a