### PR TITLE
Remove match prediction daemon advisory lock

### DIFF
--- a/app/services/match_prediction_daemon.py
+++ b/app/services/match_prediction_daemon.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import AsyncIterator, Iterable, Optional, Tuple
+from typing import AsyncIterator, Iterable
 
 from fastapi import HTTPException
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import async_session_factory
 from app.models import PredictionQueue
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
 SLEEP_INTERVAL_SECONDS = 5 * 60
-_DAEMON_LOCK_ID = 42_004_200  # Arbitrary constant that uniquely identifies the daemon lock.
 
 
 @dataclass(frozen=True)
@@ -73,61 +72,6 @@ async def _mark_match_complete(session: AsyncSession, match: QueuedMatch) -> Non
         )
     )
     await session.commit()
-
-
-async def acquire_prediction_daemon_lock() -> Tuple[bool, Optional[AsyncConnection]]:
-    """Attempt to acquire a database-backed lock for the daemon.
-
-    Uses PostgreSQL advisory locks so that only one worker process runs
-    the prediction daemon. If advisory locks aren't supported, it runs
-    without coordination.
-    """
-    async with async_session_factory() as session:
-        connection = await session.connection()
-        dialect_name = connection.dialect.name
-
-        if not dialect_name.startswith("postgresql"):
-            logger.info(
-                "Database dialect '%s' does not support advisory locks; "
-                "running prediction daemon without coordination.",
-                dialect_name,
-            )
-            return True, None
-
-        try:
-            # Inline the constant lock ID directly into SQL to avoid prepared statements
-            result = await(await connection.execution_options(compiled_cache=None)).execute(
-                text(f"SELECT pg_try_advisory_lock({int(_DAEMON_LOCK_ID)})")
-            )
-            acquired = bool(result.scalar())
-            if acquired:
-                logger.info("Acquired match prediction daemon advisory lock.")
-                return True, connection
-
-            logger.info(
-                "Another worker already holds the match prediction daemon advisory lock; skipping daemon start."
-            )
-        except SQLAlchemyError:
-            logger.exception(
-                "Failed to acquire match prediction daemon lock; daemon will not be started in this worker."
-            )
-
-
-    # If we reach here, lock not acquired or exception occurred
-    return False, None
-
-
-async def release_prediction_daemon_lock(connection: AsyncConnection) -> None:
-    """Release the advisory lock acquired for the daemon."""
-    try:
-        await connection.execute(
-            text("SELECT pg_advisory_unlock(:lock_id)"),
-            {"lock_id": _DAEMON_LOCK_ID},
-        )
-    except SQLAlchemyError:
-        logger.exception("Failed to release match prediction daemon advisory lock.")
-    finally:
-        await connection.close()
 
 
 async def process_prediction_queue() -> bool:
@@ -189,9 +133,7 @@ async def process_prediction_queue() -> bool:
 
 
 __all__ = [
-    "acquire_prediction_daemon_lock",
     "QueuedMatch",
-    "release_prediction_daemon_lock",
     "SLEEP_INTERVAL_SECONDS",
     "process_prediction_queue",
     "session_scope",

--- a/scripts/run_match_prediction_daemon.py
+++ b/scripts/run_match_prediction_daemon.py
@@ -9,9 +9,7 @@ from app.db.database import init_db
 from app.logging_config import configure_logging
 from app.services.match_prediction_daemon import (
     SLEEP_INTERVAL_SECONDS,
-    acquire_prediction_daemon_lock,
     process_prediction_queue,
-    release_prediction_daemon_lock,
 )
 
 configure_logging()
@@ -20,11 +18,6 @@ logger = logging.getLogger(__name__)
 
 async def _daemon_loop() -> None:
     """Continuously process queued match predictions."""
-
-    should_run, lock_connection = await acquire_prediction_daemon_lock()
-    if not should_run:
-        logger.info("Another match prediction daemon is already running; exiting.")
-        return
 
     logger.info("Match prediction daemon started.")
 
@@ -40,9 +33,6 @@ async def _daemon_loop() -> None:
     except asyncio.CancelledError:
         logger.info("Match prediction daemon cancelled; shutting down.")
         raise
-    finally:
-        if lock_connection is not None:
-            await release_prediction_daemon_lock(lock_connection)
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- remove the advisory locking utilities from the match prediction daemon service
- simplify the standalone daemon runner to always process the queue without lock coordination

## Testing
- pytest tests/test_prediction_queue_queueing.py

------
https://chatgpt.com/codex/tasks/task_e_6900116818588326809466fb5b7b06b1