### PR TITLE
Restart match prediction daemon during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,5 +51,21 @@ jobs:
             screen -S 1349 -p 0 -X stuff $'source venv/bin/activate\n'
             screen -S 1349 -p 0 -X stuff $'uvicorn app.main:app --host 127.0.0.1 --port 8000 --workers 3 --proxy-headers\n'
 
+            echo "🔹 Restarting match prediction daemon in screen 39086..."
+            if screen -list | grep -q "39086"; then
+              echo "  ➤ Stopping running process inside screen 39086"
+              screen -S 39086 -p 0 -X stuff $'\003'
+              sleep 5
+            else
+              echo "  ➤ Screen 39086 not found, creating it"
+              screen -dmS 39086
+              sleep 2
+            fi
+
+            echo "  ➤ Starting match prediction daemon within screen 39086"
+            screen -S 39086 -p 0 -X stuff $'cd /opt/Scouting-App-Backend\n'
+            screen -S 39086 -p 0 -X stuff $'source venv/bin/activate\n'
+            screen -S 39086 -p 0 -X stuff $'python -m scripts.run_match_prediction_daemon\n'
+
             echo "✅ Deployment complete."
           EOF


### PR DESCRIPTION
## Summary
- restart the match prediction daemon within screen 39086 as part of the deploy job

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690014ddf57c8326b755c190b706b2dc