### PR TITLE
Store RP and coop values from TBA score breakdown

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -435,6 +435,17 @@ async def _persist_event_tba_matches(
         ):
             continue
 
+        coopertition_met = False
+        if isinstance(breakdown, dict):
+            red_breakdown = breakdown.get("red")
+            blue_breakdown = breakdown.get("blue")
+            coopertition_met = bool(
+                isinstance(red_breakdown, dict)
+                and isinstance(blue_breakdown, dict)
+                and red_breakdown.get("coopertitionCriteriaMet")
+                and blue_breakdown.get("coopertitionCriteriaMet")
+            )
+
         for color_key, alliance_enum in (("red", Alliance.RED), ("blue", Alliance.BLUE)):
             alliance_info = alliances.get(color_key) or {}
             team_keys = alliance_info.get("team_keys") or []
@@ -445,6 +456,19 @@ async def _persist_event_tba_matches(
                 breakdown.get(color_key),
                 team_numbers,
             )
+
+            alliance_breakdown = breakdown.get(color_key)
+            rp_value: Optional[int] = None
+            if isinstance(alliance_breakdown, dict):
+                rp_raw = alliance_breakdown.get("rp")
+                if rp_raw is not None:
+                    try:
+                        rp_value = int(rp_raw)
+                    except (TypeError, ValueError):
+                        rp_value = None
+
+            parsed_breakdown["rp"] = rp_value
+            parsed_breakdown["coop"] = 1 if coopertition_met else 0
 
             statement = select(tba_model).where(
                 tba_model.event_key == event_key,

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -1643,6 +1643,17 @@ async def update_tba_match_data_for_pending_alliances(
             match_data = response.json()
             score_breakdown = match_data.get("score_breakdown") or {}
 
+            coopertition_met = False
+            if isinstance(score_breakdown, dict):
+                red_breakdown = score_breakdown.get("red")
+                blue_breakdown = score_breakdown.get("blue")
+                coopertition_met = bool(
+                    isinstance(red_breakdown, dict)
+                    and isinstance(blue_breakdown, dict)
+                    and red_breakdown.get("coopertitionCriteriaMet")
+                    and blue_breakdown.get("coopertitionCriteriaMet")
+                )
+
             for alliance_payload in match_payload["alliances"]:
                 alliance_enum: Alliance = alliance_payload["alliance"]
                 color_key = alliance_enum.value.lower()
@@ -1652,6 +1663,18 @@ async def update_tba_match_data_for_pending_alliances(
                     alliance_breakdown,
                     alliance_payload["teams"],
                 )
+
+                rp_value: Optional[int] = None
+                if isinstance(alliance_breakdown, dict):
+                    rp_raw = alliance_breakdown.get("rp")
+                    if rp_raw is not None:
+                        try:
+                            rp_value = int(rp_raw)
+                        except (TypeError, ValueError):
+                            rp_value = None
+
+                parsed["rp"] = rp_value
+                parsed["coop"] = 1 if coopertition_met else 0
 
                 validations: List[DataValidation] = alliance_payload["validations"]
                 should_attempt_auto_validate = (


### PR DESCRIPTION
## Summary
- capture ranking points from the TBA score breakdown when persisting match data
- mark coop as achieved when both alliances report coopertition criteria met

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69001e0d31288326964a5b47209fe8a1