### PR TITLE
Store TBA total points in match score

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -470,6 +470,25 @@ async def _persist_event_tba_matches(
             parsed_breakdown["rp"] = rp_value
             parsed_breakdown["coop"] = 1 if coopertition_met else 0
 
+            score_value: Optional[int] = None
+            if isinstance(alliance_breakdown, dict):
+                total_points_raw = alliance_breakdown.get("totalPoints")
+                if total_points_raw is not None:
+                    try:
+                        score_value = int(total_points_raw)
+                    except (TypeError, ValueError):
+                        score_value = None
+
+            if score_value is None:
+                score_raw = alliance_info.get("score")
+                if score_raw is not None:
+                    try:
+                        score_value = int(score_raw)
+                    except (TypeError, ValueError):
+                        score_value = None
+
+            parsed_breakdown["score"] = score_value
+
             statement = select(tba_model).where(
                 tba_model.event_key == event_key,
                 tba_model.match_number == match_number,

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -563,7 +563,7 @@ async def _calculate_combined_match_data(
 def _tba_matches_combined_data(
     event_year: int, tba_data: Dict[str, Any], combined_data: Dict[str, Any]
 ) -> bool:
-    ignored_fields_by_year: Dict[int, Set[str]] = {2025: {"net", "processor"}}
+    ignored_fields_by_year: Dict[int, Set[str]] = {2025: {"net", "processor", "score"}}
     ignored_fields = ignored_fields_by_year.get(event_year, set())
 
     for field, tba_value in tba_data.items():
@@ -1642,6 +1642,7 @@ async def update_tba_match_data_for_pending_alliances(
 
             match_data = response.json()
             score_breakdown = match_data.get("score_breakdown") or {}
+            alliances = match_data.get("alliances") or {}
 
             coopertition_met = False
             if isinstance(score_breakdown, dict):
@@ -1658,6 +1659,7 @@ async def update_tba_match_data_for_pending_alliances(
                 alliance_enum: Alliance = alliance_payload["alliance"]
                 color_key = alliance_enum.value.lower()
                 alliance_breakdown = score_breakdown.get(color_key)
+                alliance_info = alliances.get(color_key) or {}
                 parsed = _parse_tba_breakdown(
                     event.year,
                     alliance_breakdown,
@@ -1675,6 +1677,25 @@ async def update_tba_match_data_for_pending_alliances(
 
                 parsed["rp"] = rp_value
                 parsed["coop"] = 1 if coopertition_met else 0
+
+                score_value: Optional[int] = None
+                if isinstance(alliance_breakdown, dict):
+                    total_points_raw = alliance_breakdown.get("totalPoints")
+                    if total_points_raw is not None:
+                        try:
+                            score_value = int(total_points_raw)
+                        except (TypeError, ValueError):
+                            score_value = None
+
+                if score_value is None:
+                    score_raw = alliance_info.get("score")
+                    if score_raw is not None:
+                        try:
+                            score_value = int(score_raw)
+                        except (TypeError, ValueError):
+                            score_value = None
+
+                parsed["score"] = score_value
 
                 validations: List[DataValidation] = alliance_payload["validations"]
                 should_attempt_auto_validate = (

--- a/tests/test_tba_auto_validation.py
+++ b/tests/test_tba_auto_validation.py
@@ -5,6 +5,7 @@ import pytest
 from sqlmodel import select
 
 from app.models import (
+    Alliance,
     DataValidation,
     Endgame2025,
     FRCEvent,
@@ -13,6 +14,7 @@ from app.models import (
     Organization,
     OrganizationEvent,
     Season,
+    TBAMatchData2025,
     TeamRecord,
     User,
     UserOrganization,
@@ -62,6 +64,7 @@ class _DummyAsyncClient:
                         },
                         "netAlgaeCount": 12,
                         "wallAlgaeCount": 34,
+                        "totalPoints": 123,
                         "endGameRobot1": "DeepCage",
                         "endGameRobot2": "Parked",
                         "endGameRobot3": None,
@@ -92,6 +95,7 @@ class _DummyAsyncClientParkNone(_DummyAsyncClient):
                         },
                         "netAlgaeCount": 12,
                         "wallAlgaeCount": 34,
+                        "totalPoints": 123,
                         "endGameRobot1": "DeepCage",
                         "endGameRobot2": None,
                         "endGameRobot3": None,
@@ -238,6 +242,18 @@ async def test_alliance_validations_marked_valid_when_tba_matches(monkeypatch):
         assert len(validations) == 3
         assert all(v.validation_status == ValidationStatus.VALID for v in validations)
         assert result["updated_validations"] == 3
+
+        tba_result = await session.execute(
+            select(TBAMatchData2025).where(
+                TBAMatchData2025.event_key == event.event_key,
+                TBAMatchData2025.match_level == "qm",
+                TBAMatchData2025.match_number == 1,
+                TBAMatchData2025.alliance == Alliance.RED,
+            )
+        )
+        red_record = tba_result.scalars().first()
+        assert red_record is not None
+        assert red_record.score == 123
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist TBA match score by reading totalPoints from the TBA score breakdown with a fallback to the alliance score
- exclude score from combined-data comparisons so validation tolerance is unchanged
- extend the TBA auto-validation test doubles to include totalPoints and assert the stored score value

## Testing
- SUPABASE_JWT_SECRET=test pytest tests/test_tba_auto_validation.py *(fails: async def functions are not natively supported without pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_69001fe9fba0832687cf40c73d08ef4a