### PR TITLE
Queue ranking predictions after match simulations

### DIFF
--- a/app/services/match_prediction_daemon.py
+++ b/app/services/match_prediction_daemon.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import async_session_factory
-from app.models import PredictionQueue
+from app.models import PredictionQueue, RankingPredictionQueue
 from app.services.match_prediction import simulate_match_prediction
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,40 @@ async def _mark_match_complete(session: AsyncSession, match: QueuedMatch) -> Non
     await session.commit()
 
 
+async def _enqueue_ranking_predictions(
+    session: AsyncSession,
+    *,
+    event_key: str,
+    organization_ids: Iterable[int],
+) -> None:
+    """Queue ranking predictions for organizations impacted by match simulations."""
+
+    unique_org_ids = {
+        int(org_id)
+        for org_id in organization_ids
+        if org_id is not None
+    }
+
+    if not unique_org_ids:
+        return
+
+    existing_statement = select(RankingPredictionQueue.organization_id).where(
+        RankingPredictionQueue.event_key == event_key,
+        RankingPredictionQueue.organization_id.in_(list(unique_org_ids)),
+    )
+    existing_result = await session.execute(existing_statement)
+    existing_org_ids = set(existing_result.scalars().all())
+
+    missing_org_ids = unique_org_ids - existing_org_ids
+    if not missing_org_ids:
+        return
+
+    session.add_all(
+        RankingPredictionQueue(event_key=event_key, organization_id=org_id)
+        for org_id in missing_org_ids
+    )
+
+
 async def process_prediction_queue() -> bool:
     """Process all queued matches once.
 
@@ -95,11 +129,16 @@ async def process_prediction_queue() -> bool:
                     match.match_level,
                     match.match_number,
                 )
-                await simulate_match_prediction(
+                results = await simulate_match_prediction(
                     session,
                     match.event_key,
                     match.match_level,
                     match.match_number,
+                )
+                await _enqueue_ranking_predictions(
+                    session,
+                    event_key=match.event_key,
+                    organization_ids=(results or {}).keys(),
                 )
                 await _mark_match_complete(session, match)
                 work_completed = True

--- a/tests/test_match_prediction_daemon.py
+++ b/tests/test_match_prediction_daemon.py
@@ -1,0 +1,108 @@
+import asyncio
+import os
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+from sqlmodel import select
+
+from app.models import (
+    FRCEvent,
+    Organization,
+    PredictionQueue,
+    RankingPredictionQueue,
+)
+from app.services import match_prediction_daemon
+from tests.conftest import AsyncSessionLocal
+
+
+def test_process_prediction_queue_enqueues_ranking_predictions(
+    monkeypatch, setup_database
+) -> None:
+    """Processing match predictions queues ranking prediction jobs once per event/org."""
+
+    monkeypatch.setattr(
+        match_prediction_daemon,
+        "async_session_factory",
+        AsyncSessionLocal,
+        raising=False,
+    )
+
+    event_key = "2025daemon"
+
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            event = FRCEvent(
+                event_key=event_key,
+                event_name="Daemon Event",
+                year=2025,
+                week=1,
+            )
+            org_a = Organization(name="Daemon Org A", team_number=111)
+            org_b = Organization(name="Daemon Org B", team_number=222)
+
+            session.add_all([event, org_a, org_b])
+            await session.commit()
+            await session.refresh(org_a)
+            await session.refresh(org_b)
+
+            org_a_id = int(org_a.id)
+            org_b_id = int(org_b.id)
+
+            session.add_all(
+                [
+                    PredictionQueue(
+                        event_key=event_key,
+                        match_number=1,
+                        match_level="qm",
+                        organization_id=org_a_id,
+                    ),
+                    PredictionQueue(
+                        event_key=event_key,
+                        match_number=2,
+                        match_level="qm",
+                        organization_id=org_b_id,
+                    ),
+                    RankingPredictionQueue(
+                        event_key=event_key,
+                        organization_id=org_a_id,
+                    ),
+                ]
+            )
+            await session.commit()
+
+        async def fake_simulate_match_prediction(
+            session, event_code, match_level, match_number
+        ):
+            return {
+                org_a_id: {"dummy": 1.0},
+                org_b_id: {"dummy": 2.0},
+            }
+
+        monkeypatch.setattr(
+            match_prediction_daemon,
+            "simulate_match_prediction",
+            fake_simulate_match_prediction,
+        )
+
+        work_completed = await match_prediction_daemon.process_prediction_queue()
+        assert work_completed is True
+
+        async with AsyncSessionLocal() as session:
+            ranking_result = await session.execute(
+                select(RankingPredictionQueue).where(
+                    RankingPredictionQueue.event_key == event_key
+                )
+            )
+            ranking_entries = {
+                (row.event_key, row.organization_id)
+                for row in ranking_result.scalars().all()
+            }
+            assert ranking_entries == {
+                (event_key, org_a_id),
+                (event_key, org_b_id),
+            }
+
+            queue_result = await session.execute(select(PredictionQueue))
+            assert queue_result.scalars().all() == []
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- enqueue ranking prediction jobs whenever the match prediction daemon writes new simulations
- avoid duplicate ranking queue entries by checking for existing event/org combinations
- add coverage for the daemon to ensure ranking queue jobs are created and prediction jobs are cleared

## Testing
- pytest tests/test_match_prediction_daemon.py

------
https://chatgpt.com/codex/tasks/task_e_69002cdd2dc08326a6696fa44e7cb5e6