### PR TITLE
Skip ranking predictions for playoff matches

### DIFF
--- a/app/services/ranking_prediction_daemon.py
+++ b/app/services/ranking_prediction_daemon.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 SLEEP_INTERVAL_SECONDS = 20 * 60
 SIMULATION_COUNT = 10_000
 
+# Only qualification matches impact ranking point totals. Playoff matches
+# (quarterfinals, semifinals, finals, etc.) should not be considered when
+# simulating future rankings.
+QUALIFICATION_MATCH_LEVELS = {"qm"}
+
 
 @dataclass(frozen=True)
 class QueuedRankingPrediction:
@@ -185,9 +190,20 @@ async def _collect_simulation_inputs(
         MatchSchedule.event_key == event.event_key
     )
     schedule_result = await session.execute(schedule_stmt)
-    schedule_entries = list(schedule_result.scalars().all())
-    if not schedule_entries:
+    all_schedule_entries = list(schedule_result.scalars().all())
+    if not all_schedule_entries:
         raise IncompleteDataError("No match schedule data found for event.")
+
+    schedule_entries = [
+        entry
+        for entry in all_schedule_entries
+        if (entry.match_level or "").lower() in QUALIFICATION_MATCH_LEVELS
+    ]
+
+    if not schedule_entries:
+        raise NoUnplayedMatchesError(
+            f"No qualification matches remaining for event {event.event_key}."
+        )
 
     tba_stmt = select(tba_model).where(tba_model.event_key == event.event_key)
     tba_result = await session.execute(tba_stmt)

--- a/tests/test_ranking_prediction_daemon.py
+++ b/tests/test_ranking_prediction_daemon.py
@@ -194,6 +194,99 @@ def test_process_queue_creates_predictions(monkeypatch, setup_database) -> None:
     asyncio.run(_run_test())
 
 
+def test_process_queue_ignores_playoff_matches(monkeypatch, setup_database) -> None:
+    monkeypatch.setattr(
+        ranking_prediction_daemon,
+        "async_session_factory",
+        AsyncSessionLocal,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ranking_prediction_daemon,
+        "_create_rng",
+        _seed_rng,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ranking_prediction_daemon,
+        "SIMULATION_COUNT",
+        100,
+        raising=False,
+    )
+
+    event_key = "2025rankings-playoffs"
+
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            org_id = await _create_common_setup(session, event_key, "Ranking Org")
+
+            session.add_all(
+                [
+                    TBAMatchData2025(
+                        event_key=event_key,
+                        match_number=1,
+                        match_level="qm",
+                        alliance=Alliance.RED,
+                        score=None,
+                    ),
+                    TBAMatchData2025(
+                        event_key=event_key,
+                        match_number=1,
+                        match_level="qm",
+                        alliance=Alliance.BLUE,
+                        score=None,
+                    ),
+                    RankingPredictionQueue(
+                        event_key=event_key,
+                        organization_id=org_id,
+                    ),
+                    MatchSchedule(
+                        event_key=event_key,
+                        match_number=2,
+                        match_level="sf",
+                        red1_id=1,
+                        red2_id=2,
+                        red3_id=3,
+                        blue1_id=4,
+                        blue2_id=5,
+                        blue3_id=6,
+                    ),
+                    TBAMatchData2025(
+                        event_key=event_key,
+                        match_number=2,
+                        match_level="sf",
+                        alliance=Alliance.RED,
+                        score=None,
+                    ),
+                    TBAMatchData2025(
+                        event_key=event_key,
+                        match_number=2,
+                        match_level="sf",
+                        alliance=Alliance.BLUE,
+                        score=None,
+                    ),
+                ]
+            )
+            await session.commit()
+
+        work_completed = await ranking_prediction_daemon.process_ranking_prediction_queue()
+        assert work_completed is True
+
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(RankingPredictions).where(
+                    RankingPredictions.event_key == event_key
+                )
+            )
+            rows = sorted(result.scalars().all(), key=lambda row: row.team_number)
+            assert len(rows) == 6
+
+            queue_result = await session.execute(select(RankingPredictionQueue))
+            assert queue_result.scalars().all() == []
+
+    asyncio.run(_run_test())
+
+
 def test_queue_entry_removed_when_no_matches(monkeypatch, setup_database) -> None:
     monkeypatch.setattr(
         ranking_prediction_daemon,


### PR DESCRIPTION
## Summary
- ensure ranking prediction simulations only consider qualification-level matches
- stop processing when only playoff matches remain in the schedule
- add regression coverage for ignoring playoff matches during ranking predictions

## Testing
- pytest tests/test_ranking_prediction_daemon.py::test_process_queue_ignores_playoff_matches -q

------
https://chatgpt.com/codex/tasks/task_e_690033b8b3a883269b2d9eb1f2dd47f4