### PR TITLE
Fix flipped ranking prediction percentiles

### DIFF
--- a/app/services/ranking_prediction_daemon.py
+++ b/app/services/ranking_prediction_daemon.py
@@ -473,8 +473,12 @@ def _simulate_rankings(
         idx = team_to_index[team]
         team_ranks = ranks[:, idx]
         statistics[team] = {
-            "rank_5": float(_compute_percentile(team_ranks, 5)),
-            "rank_95": float(_compute_percentile(team_ranks, 95)),
+            # rank_5 represents the worst-case outcome (95th percentile) while
+            # rank_95 reflects the best-case outcome (5th percentile). This aligns
+            # with how the values are displayed to users, ensuring the percentile
+            # labels are not inverted.
+            "rank_5": float(_compute_percentile(team_ranks, 95)),
+            "rank_95": float(_compute_percentile(team_ranks, 5)),
             "median_rank": float(_compute_median_rank(team_ranks)),
             "mean_rank": float(np.mean(team_ranks)),
             "mean_rp": float(np.mean(rp_totals[:, idx])),

--- a/tests/test_ranking_prediction_daemon.py
+++ b/tests/test_ranking_prediction_daemon.py
@@ -28,6 +28,43 @@ def _seed_rng() -> np.random.Generator:
     return np.random.default_rng(42)
 
 
+def test_simulate_rankings_percentiles_are_not_flipped(monkeypatch) -> None:
+    recorded_percentiles = []
+
+    def _fake_percentile(ranks, percentile):  # type: ignore[override]
+        recorded_percentiles.append(percentile)
+        return int(percentile)
+
+    monkeypatch.setattr(
+        ranking_prediction_daemon,
+        "_compute_percentile",
+        _fake_percentile,
+        raising=False,
+    )
+
+    rankings = {
+        1: EventRankings(
+            event_key="test",
+            rank=1,
+            team_number=1,
+            ranking_points=0,
+            matches_played=0,
+            ranking_tiebreaker_1=0.0,
+            ranking_tiebreaker_2=0.0,
+        )
+    }
+
+    statistics = ranking_prediction_daemon._simulate_rankings(
+        matches=[],
+        rankings=rankings,
+        n_simulations=1,
+    )
+
+    assert statistics[1]["rank_5"] == 95
+    assert statistics[1]["rank_95"] == 5
+    assert recorded_percentiles == [95, 5]
+
+
 async def _create_common_setup(session, event_key: str, organization_name: str) -> int:
     season_stmt = select(Season).where(Season.year == 2025)
     season_result = await session.execute(season_stmt)


### PR DESCRIPTION
## Summary
- ensure ranking prediction statistics map percentile values to the correct rank fields
- add a regression test that guards against swapping the 5th and 95th percentile values

## Testing
- pytest tests/test_ranking_prediction_daemon.py

------
https://chatgpt.com/codex/tasks/task_e_69003999a70483268617ef0da7864ae6