### PR TITLE
Add daily TBA sync daemon and remove admin sync endpoints

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,14 +1,13 @@
-from http.client import HTTPException
 from uuid import UUID
-from fastapi import APIRouter, Depends
-from sqlmodel.ext.asyncio.session import AsyncSession
-from sqlmodel import select, delete, SQLModel
-from typing import Optional, List, Set
 from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
 from app.auth.dependencies import require_site_admin
 from app.db.database import get_session
-from dotenv import load_dotenv
-import requests, os, httpx, asyncio, traceback, aiohttp
 
 
 router = APIRouter(
@@ -20,21 +19,10 @@ router = APIRouter(
 from app.models import (
     Organization,
     OrganizationFeatureSettings,
-    TeamRecord,
-    FRCEvent,
-    TeamEvent,
+    User,
     UserOrganization,
     UserRole,
-    User,
 )
-
-load_dotenv()
-
-ALL_TEAMS_URL = "https://www.thebluealliance.com/api/v3/teams/{page_num}/simple"
-TBA_API_ENDPOINT = "https://www.thebluealliance.com/api/v3"
-TBA_API_KEY = os.getenv("TBA_API_KEY")
-
-semaphore = asyncio.Semaphore(10)
 
 class CreateOrganizationCommand(SQLModel):
     name: str
@@ -113,64 +101,6 @@ async def create_organization(
         team_number=newOrg.team_number
     )
 
-@router.post("/teams/update")
-async def update_team_list(session: AsyncSession = Depends(get_session)) -> dict:
-    pagenum = 0
-    teams_to_add = []
-    updates = 0
-
-    # 1. Fetch all teams from TBA API
-    all_teams = []
-    async with httpx.AsyncClient() as client:
-        while True:
-            response = await client.get(
-                url=ALL_TEAMS_URL.format(page_num=str(pagenum)),
-                headers={'X-TBA-Auth-Key': TBA_API_KEY, 'accept': 'application/json'}
-            )
-            team_page = response.json()
-            if not team_page:
-                break
-            all_teams.extend(team_page)
-            pagenum += 1
-
-    # 2. Fetch all existing teams from the database in one query
-    statement = select(TeamRecord)
-    result = await session.exec(statement)
-    existing_teams = {team.team_number: team for team in result.all()}
-
-    # 3. Process teams
-    for team in all_teams:
-        team_number = team["team_number"]
-        team_name = team["nickname"]
-        location = f"{team['city']}, {team['state_prov']}, {team['country']}"
-
-        if team_number in existing_teams:
-            existing_team = existing_teams[team_number]
-            if existing_team.team_name != team_name:
-                existing_team.team_name = team_name
-                updates += 1
-        else:
-            new_team = TeamRecord(
-                team_number,
-                team_name
-            )
-            new_team.location=location
-            teams_to_add.append(new_team)
-
-    # 4. Add new teams
-    for team in teams_to_add:
-        session.add(team)
-
-    # 5. Commit all changes in a single transaction
-    await session.commit()
-
-    return {
-        "added": len(teams_to_add),
-        "updated": updates,
-        "total_processed": len(all_teams),
-    }
-
-
 @router.post(
     "/organizations/members",
     response_model=ManageOrganizationMemberResponse,
@@ -206,102 +136,3 @@ async def add_or_promote_organization_member(
         user_organization_id=membership.id,
         role=membership.role,
     )
-
-async def fetch_event_teams(event_key: str, headers: dict):
-    async with semaphore:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(f"{TBA_API_ENDPOINT}/event/{event_key}/teams/simple", headers=headers)
-            return response.json()
-
-@router.post("/events/registration/{year}")
-async def import_event_registration(year: int, session: AsyncSession = Depends(get_session)):
-    try:
-        # 1. Fetch all events for the year from TBA API
-        events_url = f"{TBA_API_ENDPOINT}/events/{year}"
-        headers = {"X-TBA-Auth-Key": TBA_API_KEY, "accept": "application/json"}
-
-        async with httpx.AsyncClient() as client:
-            response = await client.get(events_url, headers=headers)
-            events_data = response.json()
-
-        if not isinstance(events_data, list) or len(events_data) == 0:
-            return {"status": "error", "message": f"No events found for year {year} on TBA"}
-
-        # 2. Fetch existing events in DB
-        statement = select(FRCEvent)
-        result = await session.exec(statement)
-        existing_events = {e.event_key: e for e in result.all()}
-
-        # 3. Process each event and prepare async team fetches
-        team_fetch_tasks = {}
-        for event in events_data:
-            event_type = event["event_type"]
-            if event_type == 100:
-                continue  # skip off-season events
-
-            event_key = str(event["key"])
-            event_name = str(event["name"])
-            short_name = str(event["short_name"])
-            if event_type == 99:
-                week = 99
-            elif year < 2026:
-                week = 8 if event_type in [3, 4] else int(event["week"] + 1)
-            else:
-                week = 9 if event_type in [3, 4] else int(event["week"] + 1)
-            year_event = int(event_key[:4])
-
-            # Add or update FRCEvent
-            if event_key in existing_events:
-                db_event = existing_events[event_key]
-                if db_event.event_name != event_name or db_event.week != week:
-                    db_event.event_name = event_name
-                    db_event.short_name = short_name
-                    db_event.week = week
-                    db_event.year = year_event
-            else:
-                new_event = FRCEvent(
-                    event_key=event_key,
-                    event_name=event_name,
-                    short_name=short_name,
-                    year=year_event,
-                    week=week
-                )
-                session.add(new_event)
-                existing_events[event_key] = new_event
-
-            # Schedule async fetch of event teams
-            team_fetch_tasks[event_key] = fetch_event_teams(event_key, headers)
-
-        # 4. Fetch all event teams concurrently
-        all_team_results = await asyncio.gather(*team_fetch_tasks.values())
-        event_keys = list(team_fetch_tasks.keys())
-
-        for idx, event_key in enumerate(event_keys):
-            teams_data = all_team_results[idx]
-
-            # Fetch existing team registrations
-            statement_teams = select(TeamEvent).where(TeamEvent.event_key == event_key)
-            result_teams = await session.exec(statement_teams)
-            existing_team_events = {te.team_number: te for te in result_teams.all()}
-
-            current_teams: Set[int] = set()
-            for team in teams_data:
-                team_number = int(team["team_number"])
-                current_teams.add(team_number)
-                if team_number not in existing_team_events:
-                    new_team_event = TeamEvent(event_key=event_key, team_number=team_number)
-                    session.add(new_team_event)
-
-            # Remove registrations for teams no longer present
-            for team_number, team_event in existing_team_events.items():
-                if team_number not in current_teams:
-                    await session.delete(team_event)
-
-        # 5. Commit all changes
-        await session.commit()
-
-        return {"status": "success", "year": year, "events_processed": len(events_data)}
-
-    except Exception:
-        traceback.print_exc()
-        return {"status": "error", "message": f"Error importing events for year {year} from TBA"}

--- a/app/services/daily_data_sync_daemon.py
+++ b/app/services/daily_data_sync_daemon.py
@@ -1,0 +1,61 @@
+"""Utilities for performing daily synchronisation with external services."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from typing import Dict, List
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models import Season
+from app.services.tba_sync import import_event_registration, update_team_list
+
+logger = logging.getLogger(__name__)
+
+RUN_HOUR_LOCAL = 7
+SLEEP_INTERVAL_SECONDS = 45
+
+
+async def perform_daily_sync(session: AsyncSession) -> Dict[str, object]:
+    """Execute the full daily data synchronisation workflow."""
+
+    logger.info("Starting daily synchronisation run.")
+
+    team_result = await update_team_list(session)
+
+    seasons_statement = select(Season).where(Season.active.is_(True))
+    seasons_result = await session.exec(seasons_statement)
+    active_seasons: List[Season] = seasons_result.all()
+
+    logger.info("Found %d active seasons for registration sync.", len(active_seasons))
+
+    event_results: List[Dict[str, object]] = []
+    for season in active_seasons:
+        logger.info("Syncing registrations for season %s (%s).", season.id, season.year)
+        result = await import_event_registration(season.year, session)
+        event_results.append({"season_id": season.id, **result})
+
+        if result.get("status") != "success":
+            logger.warning(
+                "Event registration import for year %s completed with status %s.",
+                season.year,
+                result.get("status"),
+            )
+
+    logger.info("Daily synchronisation run finished.")
+
+    return {"teams": team_result, "events": event_results}
+
+
+def should_run_sync(now: datetime, last_run_date: date | None) -> bool:
+    """Return ``True`` when the sync should execute for the current day."""
+
+    if now.hour != RUN_HOUR_LOCAL:
+        return False
+
+    if last_run_date is None:
+        return True
+
+    return last_run_date != now.date()

--- a/app/services/tba_sync.py
+++ b/app/services/tba_sync.py
@@ -1,0 +1,210 @@
+"""Services for synchronising data from The Blue Alliance."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Dict, List, Set
+
+import httpx
+from dotenv import load_dotenv
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models import FRCEvent, TeamEvent, TeamRecord
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+ALL_TEAMS_URL = "https://www.thebluealliance.com/api/v3/teams/{page_num}/simple"
+TBA_API_ENDPOINT = os.getenv("TBA_API_ENDPOINT", "https://www.thebluealliance.com/api/v3")
+TBA_API_KEY = os.getenv("TBA_API_KEY")
+
+# Limit concurrent team fetches to avoid overwhelming the TBA API.
+_team_fetch_semaphore = asyncio.Semaphore(10)
+
+
+class TBASyncError(RuntimeError):
+    """Raised when a synchronisation task cannot be completed."""
+
+
+async def update_team_list(session: AsyncSession) -> Dict[str, int]:
+    """Synchronise the list of FRC teams from The Blue Alliance."""
+
+    if not TBA_API_KEY:
+        raise TBASyncError("TBA_API_KEY environment variable is not configured.")
+
+    logger.info("Fetching team list from TBA API.")
+    page_number = 0
+    all_teams: List[dict] = []
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            response = await client.get(
+                url=ALL_TEAMS_URL.format(page_num=str(page_number)),
+                headers={"X-TBA-Auth-Key": TBA_API_KEY, "accept": "application/json"},
+            )
+            response.raise_for_status()
+
+            team_page = response.json()
+            if not team_page:
+                break
+
+            all_teams.extend(team_page)
+            page_number += 1
+
+    logger.info("Fetched %d teams from TBA.", len(all_teams))
+
+    statement = select(TeamRecord)
+    result = await session.exec(statement)
+    existing_teams = {team.team_number: team for team in result.all()}
+
+    teams_to_add: List[TeamRecord] = []
+    updates = 0
+
+    for team in all_teams:
+        team_number = int(team["team_number"])
+        team_name = team["nickname"]
+        location = f"{team['city']}, {team['state_prov']}, {team['country']}"
+
+        if team_number in existing_teams:
+            existing_team = existing_teams[team_number]
+            if existing_team.team_name != team_name:
+                existing_team.team_name = team_name
+                updates += 1
+            if location and existing_team.location != location:
+                existing_team.location = location
+        else:
+            new_team = TeamRecord(team_number, team_name)
+            new_team.location = location
+            teams_to_add.append(new_team)
+
+    if teams_to_add:
+        logger.info("Adding %d new teams to database.", len(teams_to_add))
+        for team in teams_to_add:
+            session.add(team)
+
+    await session.commit()
+
+    logger.info(
+        "Team sync complete: %d added, %d updated, %d processed.",
+        len(teams_to_add),
+        updates,
+        len(all_teams),
+    )
+
+    return {
+        "added": len(teams_to_add),
+        "updated": updates,
+        "total_processed": len(all_teams),
+    }
+
+
+async def _fetch_event_teams(event_key: str, headers: Dict[str, str]) -> List[dict]:
+    async with _team_fetch_semaphore:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{TBA_API_ENDPOINT}/event/{event_key}/teams/simple",
+                headers=headers,
+            )
+            response.raise_for_status()
+            return response.json()
+
+
+async def import_event_registration(year: int, session: AsyncSession) -> Dict[str, object]:
+    """Synchronise event registrations for the specified ``year``."""
+
+    if not TBA_API_KEY:
+        raise TBASyncError("TBA_API_KEY environment variable is not configured.")
+
+    logger.info("Fetching events for %s from TBA API.", year)
+    events_url = f"{TBA_API_ENDPOINT}/events/{year}"
+    headers = {"X-TBA-Auth-Key": TBA_API_KEY, "accept": "application/json"}
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(events_url, headers=headers)
+        response.raise_for_status()
+        events_data = response.json()
+
+    if not isinstance(events_data, list) or len(events_data) == 0:
+        logger.warning("No events returned for year %s.", year)
+        return {"status": "error", "message": f"No events found for year {year} on TBA"}
+
+    statement = select(FRCEvent)
+    result = await session.exec(statement)
+    existing_events = {event.event_key: event for event in result.all()}
+
+    team_fetch_tasks: Dict[str, asyncio.Task[List[dict]]] = {}
+
+    for event in events_data:
+        event_type = event.get("event_type")
+        if event_type == 100:
+            continue
+
+        event_key = str(event["key"])
+        event_name = str(event["name"])
+        short_name = str(event["short_name"])
+
+        if event_type == 99:
+            week = 99
+        elif year < 2026:
+            week = 8 if event_type in [3, 4] else int(event["week"] + 1)
+        else:
+            week = 9 if event_type in [3, 4] else int(event["week"] + 1)
+
+        year_event = int(event_key[:4])
+
+        if event_key in existing_events:
+            db_event = existing_events[event_key]
+            if db_event.event_name != event_name or db_event.week != week:
+                db_event.event_name = event_name
+                db_event.short_name = short_name
+                db_event.week = week
+                db_event.year = year_event
+        else:
+            new_event = FRCEvent(
+                event_key=event_key,
+                event_name=event_name,
+                short_name=short_name,
+                year=year_event,
+                week=week,
+            )
+            session.add(new_event)
+            existing_events[event_key] = new_event
+
+        team_fetch_tasks[event_key] = asyncio.create_task(
+            _fetch_event_teams(event_key, headers)
+        )
+
+    all_team_results = await asyncio.gather(*team_fetch_tasks.values())
+    event_keys = list(team_fetch_tasks.keys())
+
+    for idx, event_key in enumerate(event_keys):
+        teams_data = all_team_results[idx]
+
+        statement_teams = select(TeamEvent).where(TeamEvent.event_key == event_key)
+        result_teams = await session.exec(statement_teams)
+        existing_team_events = {te.team_number: te for te in result_teams.all()}
+
+        current_teams: Set[int] = set()
+        for team in teams_data:
+            team_number = int(team["team_number"])
+            current_teams.add(team_number)
+            if team_number not in existing_team_events:
+                session.add(TeamEvent(event_key=event_key, team_number=team_number))
+
+        for team_number, team_event in existing_team_events.items():
+            if team_number not in current_teams:
+                await session.delete(team_event)
+
+    await session.commit()
+
+    logger.info(
+        "Imported registrations for %d events in %s.",
+        len(events_data),
+        year,
+    )
+
+    return {"status": "success", "year": year, "events_processed": len(events_data)}

--- a/scripts/run_daily_data_sync_daemon.py
+++ b/scripts/run_daily_data_sync_daemon.py
@@ -1,0 +1,61 @@
+"""Standalone runner for the daily data synchronisation daemon."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime
+
+from app.db.database import async_session_factory, init_db
+from app.logging_config import configure_logging
+from app.services.daily_data_sync_daemon import (
+    RUN_HOUR_LOCAL,
+    SLEEP_INTERVAL_SECONDS,
+    perform_daily_sync,
+    should_run_sync,
+)
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
+async def _daemon_loop() -> None:
+    """Run the daily sync task around the configured local hour."""
+
+    last_run_date: date | None = None
+    logger.info(
+        "Daily data sync daemon started; will run when the local hour reaches %02d:00.",
+        RUN_HOUR_LOCAL,
+    )
+
+    try:
+        while True:
+            now = datetime.now()
+
+            if should_run_sync(now, last_run_date):
+                async with async_session_factory() as session:
+                    try:
+                        results = await perform_daily_sync(session)
+                        logger.info("Daily sync completed: %s", results)
+                        last_run_date = now.date()
+                    except Exception:
+                        logger.exception("Daily sync encountered an unexpected error.")
+
+            await asyncio.sleep(SLEEP_INTERVAL_SECONDS)
+    except asyncio.CancelledError:
+        logger.info("Daily sync daemon cancelled; shutting down.")
+        raise
+
+
+async def main() -> None:
+    """Initialise application resources and run the daemon loop."""
+
+    await init_db()
+    await _daemon_loop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Daily sync daemon interrupted; exiting.")


### PR DESCRIPTION
## Summary
- extract the TBA team and event registration synchronisation logic into reusable services
- add a daily data sync daemon that refreshes teams and active season registrations around 7AM local time
- remove the admin endpoints that previously triggered the synchronisation in favour of the daemon

## Testing
- pytest *(fails: existing suite expects additional configuration and hits integrity errors)*

------
https://chatgpt.com/codex/tasks/task_e_6900f1ef87648326af195d07bc0760d7