### PR TITLE
Ensure events fallback to name when shortname missing

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -986,13 +986,17 @@ async def get_event_list_or_404(session: AsyncSession, year: int) -> List[EventR
         FRCEvent.year == year
     )
     result = await session.execute(statement)
-    return [EventResponse(
-        event_key=ev.event_key,
-        event_name=ev.event_name,
-        short_name=ev.short_name,
-        year=ev.year,
-        week=ev.week
-    ) for ev in result.scalars().all()]
+    events = result.scalars().all()
+    return [
+        EventResponse(
+            event_key=ev.event_key,
+            event_name=ev.event_name,
+            short_name=ev.short_name or ev.event_name,
+            year=ev.year,
+            week=ev.week,
+        )
+        for ev in events
+    ]
 
 
 async def get_public_organizations_for_event(session: AsyncSession, eventCode: str) -> List[Organization]:

--- a/tests/test_public_events_endpoint.py
+++ b/tests/test_public_events_endpoint.py
@@ -1,0 +1,56 @@
+import asyncio
+import os
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+from app.main import app
+from app.models import FRCEvent
+from tests.conftest import AsyncSessionLocal
+
+
+async def _prepare_events() -> list[FRCEvent]:
+    async with AsyncSessionLocal() as session:
+        events = [
+            FRCEvent(
+                event_key="2024test1",
+                event_name="Test Event 1",
+                short_name="Test1",
+                year=2024,
+                week=1,
+            ),
+            FRCEvent(
+                event_key="2024test2",
+                event_name="Test Event 2",
+                short_name=None,
+                year=2024,
+                week=2,
+            ),
+        ]
+        session.add_all(events)
+        await session.commit()
+        for event in events:
+            await session.refresh(event)
+        return events
+
+
+def test_list_events_uses_event_name_when_short_name_missing(setup_database):
+    created_events = asyncio.run(_prepare_events())
+
+    with TestClient(app) as client:
+        response = client.get("/public/events/2024")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == len(created_events)
+
+    event_with_short_name = next(
+        event for event in data if event["event_key"] == "2024test1"
+    )
+    assert event_with_short_name["short_name"] == "Test1"
+
+    event_without_short_name = next(
+        event for event in data if event["event_key"] == "2024test2"
+    )
+    assert event_without_short_name["short_name"] == "Test Event 2"


### PR DESCRIPTION
## Summary
- ensure event listings use the event name when no short name is available
- add test coverage for the public events endpoint fallback behavior

## Testing
- pytest tests/test_public_events_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_6900fa69289c8326ba67cef770d132a7