### PR TITLE
Add endpoint and service to delete team images

### DIFF
--- a/app/routes/team.py
+++ b/app/routes/team.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+from uuid import UUID
 
 from app.auth.dependencies import get_current_user
 from app.db.database import get_session
@@ -9,6 +11,7 @@ from app.services.team import (
 )
 from app.services.team_media import (
     RobotEventImageLinkResponse,
+    delete_team_image,
     list_team_images,
     upload_team_image,
 )
@@ -17,6 +20,12 @@ router = APIRouter(
     prefix="/teams",
     tags=["Team"],
 )
+
+
+class TeamImageDeleteRequest(BaseModel):
+    """Payload for deleting a stored team image."""
+
+    id: UUID
 
 
 @router.get("/{teamNumber}/info")
@@ -64,3 +73,15 @@ async def list_team_images_endpoint(
     session: AsyncSession = Depends(get_session),
 ):
     return await list_team_images(session, teamNumber, user)
+
+
+@router.delete(
+    "/image",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_team_image_endpoint(
+    payload: TeamImageDeleteRequest,
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    await delete_team_image(session=session, image_id=payload.id, user=user)

--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Iterable, Optional
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException, UploadFile, status
@@ -20,6 +21,7 @@ from app.services.event import (
     get_active_event_key_for_user,
     get_event_or_404,
     get_match_or_404,
+    require_lead_or_admin_membership,
 )
 from app.services.team import get_team_or_404
 from sqlmodel import SQLModel
@@ -272,3 +274,45 @@ async def list_match_team_images(
         )
         for team_number in team_order
     ]
+
+
+def _extract_s3_object_key(image_url: str) -> str:
+    """Return the S3 object key encoded within a stored image URL."""
+
+    parsed_url = urlparse(image_url)
+    object_key = parsed_url.path.lstrip("/")
+    if not object_key:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Stored image URL is invalid.",
+        )
+
+    return object_key
+
+
+async def delete_team_image(
+    session: AsyncSession,
+    image_id: UUID,
+    user: dict,
+) -> None:
+    """Remove a stored robot image from S3 and delete its database record."""
+
+    await require_lead_or_admin_membership(session, user)
+    event_key = await get_active_event_key_for_user(session, user)
+
+    record = await session.get(RobotEventImageLink, image_id)
+    if record is None or record.event_key != event_key:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    bucket = get_team_images_bucket()
+    object_key = _extract_s3_object_key(record.image_url)
+    s3_client = get_s3_client()
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        None,
+        lambda: s3_client.delete_object(Bucket=bucket, Key=object_key),
+    )
+
+    await session.delete(record)
+    await session.commit()

--- a/tests/test_team_image_delete.py
+++ b/tests/test_team_image_delete.py
@@ -1,0 +1,199 @@
+import asyncio
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import (
+    FRCEvent,
+    Organization,
+    OrganizationEvent,
+    RobotEventImageLink,
+    TeamRecord,
+    User,
+    UserOrganization,
+    UserRole,
+)
+from app.services import team_media
+from app.services.team_media import delete_team_image
+from tests.conftest import AsyncSessionLocal
+
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
+
+
+class StubS3Client:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+
+    def delete_object(self, Bucket: str, Key: str) -> None:  # pragma: no cover - simple stub
+        self.deleted.append((Bucket, Key))
+
+
+async def _create_base_data(session):
+    suffix = uuid4().hex[:8]
+    team_number = 4000 + int(suffix[:4], 16) % 2000
+
+    event = FRCEvent(
+        event_key=f"2024teamimg{suffix}",
+        event_name="Team Image Event",
+        short_name="TIE",
+        year=2024,
+        week=1,
+    )
+    other_event = FRCEvent(
+        event_key=f"2024otherimg{suffix}",
+        event_name="Other Event",
+        short_name="Other",
+        year=2024,
+        week=2,
+    )
+    organization = Organization(name=f"Image Org {suffix}", team_number=team_number)
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    user = User(
+        id=user_id,
+        email="team-image@example.com",
+        auth_provider="discord",
+        display_name="Team Image Admin",
+        logged_in_user_org=None,
+        created_at=now,
+        updated_at=now,
+    )
+    team = TeamRecord(teamNumber=team_number, teamName=f"Team {team_number}")
+
+    session.add_all([event, other_event, organization, user, team])
+    await session.commit()
+    await session.refresh(organization)
+
+    membership = UserOrganization(
+        user_id=user_id,
+        organization_id=organization.id,
+        role=UserRole.ADMIN,
+    )
+    session.add(membership)
+    await session.commit()
+    await session.refresh(membership)
+
+    user.logged_in_user_org = membership.id
+    session.add(user)
+    await session.commit()
+
+    active_org_event = OrganizationEvent(
+        organization_id=organization.id,
+        event_key=event.event_key,
+        public_data=True,
+        active=True,
+    )
+    session.add(active_org_event)
+
+    await session.commit()
+
+    return {
+        "user_id": user_id,
+        "membership_id": membership.id,
+        "event_key": event.event_key,
+        "other_event_key": other_event.event_key,
+        "team_number": team.team_number,
+    }
+
+
+def test_delete_team_image_removes_record_and_s3_object(monkeypatch):
+    stub = StubS3Client()
+    monkeypatch.setattr(team_media, "get_s3_client", lambda: stub)
+    monkeypatch.setattr(team_media, "get_team_images_bucket", lambda: "test-bucket")
+
+    async def runner():
+        async with AsyncSessionLocal() as session:
+            data = await _create_base_data(session)
+
+            object_path = f"{data['event_key']}/{data['team_number']}/sample.png"
+            record = RobotEventImageLink(
+                team_number=data["team_number"],
+                event_key=data["event_key"],
+                image_url=f"https://test-bucket.s3.amazonaws.com/{object_path}",
+                description="Robot pose",
+            )
+            session.add(record)
+            await session.commit()
+            await session.refresh(record)
+
+            user_payload = {"id": str(data["user_id"]), "user_org": data["membership_id"]}
+
+            await delete_team_image(session=session, image_id=record.id, user=user_payload)
+
+            assert await session.get(RobotEventImageLink, record.id) is None
+            assert stub.deleted == [("test-bucket", object_path)]
+
+    asyncio.run(runner())
+
+
+def test_delete_team_image_requires_admin_or_lead(monkeypatch):
+    stub = StubS3Client()
+    monkeypatch.setattr(team_media, "get_s3_client", lambda: stub)
+    monkeypatch.setattr(team_media, "get_team_images_bucket", lambda: "test-bucket")
+
+    async def runner():
+        async with AsyncSessionLocal() as session:
+            data = await _create_base_data(session)
+
+            membership = await session.get(UserOrganization, data["membership_id"])
+            membership.role = UserRole.MEMBER
+            await session.commit()
+            await session.refresh(membership)
+
+            object_path = f"{data['event_key']}/{data['team_number']}/sample.png"
+            record = RobotEventImageLink(
+                team_number=data["team_number"],
+                event_key=data["event_key"],
+                image_url=f"https://test-bucket.s3.amazonaws.com/{object_path}",
+            )
+            session.add(record)
+            await session.commit()
+            await session.refresh(record)
+
+            user_payload = {"id": str(data["user_id"]), "user_org": data["membership_id"]}
+
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_team_image(session=session, image_id=record.id, user=user_payload)
+
+            assert exc_info.value.status_code == 403
+            remaining = await session.get(RobotEventImageLink, record.id)
+            assert remaining is not None
+            assert stub.deleted == []
+
+    asyncio.run(runner())
+
+
+def test_delete_team_image_only_allows_active_event_records(monkeypatch):
+    stub = StubS3Client()
+    monkeypatch.setattr(team_media, "get_s3_client", lambda: stub)
+    monkeypatch.setattr(team_media, "get_team_images_bucket", lambda: "test-bucket")
+
+    async def runner():
+        async with AsyncSessionLocal() as session:
+            data = await _create_base_data(session)
+
+            record = RobotEventImageLink(
+                team_number=data["team_number"],
+                event_key=data["other_event_key"],
+                image_url=(
+                    "https://test-bucket.s3.amazonaws.com/"
+                    f"{data['other_event_key']}/{data['team_number']}/sample.png"
+                ),
+            )
+            session.add(record)
+            await session.commit()
+            await session.refresh(record)
+
+            user_payload = {"id": str(data["user_id"]), "user_org": data["membership_id"]}
+
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_team_image(session=session, image_id=record.id, user=user_payload)
+
+            assert exc_info.value.status_code == 404
+            assert await session.get(RobotEventImageLink, record.id) is not None
+            assert stub.deleted == []
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add a DELETE /teams/image route that accepts an image id payload and calls the team media service
- implement team media deletion to require admin/lead membership, remove the S3 object, and drop the database row
- exercise the happy path, permission, and event validation flows with new tests

## Testing
- pytest tests/test_team_image_delete.py

------
https://chatgpt.com/codex/tasks/task_e_690114e4c23c8326b29a73f0a993e529