### PR TITLE
Return metadata for event team images

### DIFF
--- a/app/services/team_media.py
+++ b/app/services/team_media.py
@@ -50,11 +50,19 @@ class RobotEventImageLinkResponse(SQLModel):
     uploaded_at: datetime
 
 
+class EventTeamImageSummaryResponse(BaseModel):
+    """Summary information for an individual team robot image."""
+
+    id: UUID
+    image_url: str
+    description: Optional[str] = None
+
+
 class EventTeamImagesResponse(BaseModel):
     """Response DTO for grouped team robot images at an event."""
 
     teamNumber: int
-    images: list[str]
+    images: list[EventTeamImageSummaryResponse]
 
 
 async def _ensure_team_and_event(session: AsyncSession, team_number: int, event_key: str) -> None:
@@ -196,7 +204,9 @@ async def list_event_team_images(
     statement = (
         select(
             RobotEventImageLink.team_number,
+            RobotEventImageLink.id,
             RobotEventImageLink.image_url,
+            RobotEventImageLink.description,
         )
         .where(RobotEventImageLink.event_key == event_key)
         .order_by(
@@ -207,9 +217,15 @@ async def list_event_team_images(
 
     result = await session.execute(statement)
 
-    grouped_images: dict[int, list[str]] = {}
-    for team_number, image_url in result.all():
-        grouped_images.setdefault(team_number, []).append(image_url)
+    grouped_images: dict[int, list[EventTeamImageSummaryResponse]] = {}
+    for team_number, image_id, image_url, description in result.all():
+        grouped_images.setdefault(team_number, []).append(
+            EventTeamImageSummaryResponse(
+                id=image_id,
+                image_url=image_url,
+                description=description,
+            )
+        )
 
     return [
         EventTeamImagesResponse(teamNumber=team_number, images=images)
@@ -249,7 +265,9 @@ async def list_match_team_images(
     statement = (
         select(
             RobotEventImageLink.team_number,
+            RobotEventImageLink.id,
             RobotEventImageLink.image_url,
+            RobotEventImageLink.description,
         )
         .where(
             RobotEventImageLink.event_key == event_key,
@@ -263,9 +281,17 @@ async def list_match_team_images(
 
     result = await session.execute(statement)
 
-    grouped_images: dict[int, list[str]] = {team_number: [] for team_number in team_order}
-    for team_number, image_url in result.all():
-        grouped_images.setdefault(team_number, []).append(image_url)
+    grouped_images: dict[int, list[EventTeamImageSummaryResponse]] = {
+        team_number: [] for team_number in team_order
+    }
+    for team_number, image_id, image_url, description in result.all():
+        grouped_images.setdefault(team_number, []).append(
+            EventTeamImageSummaryResponse(
+                id=image_id,
+                image_url=image_url,
+                description=description,
+            )
+        )
 
     return [
         EventTeamImagesResponse(

--- a/tests/test_event_images.py
+++ b/tests/test_event_images.py
@@ -119,18 +119,21 @@ async def _prepare_event_images_data():
                 team_number=team_one.team_number,
                 event_key=event.event_key,
                 image_url="https://cdn.example.com/team1111-latest.jpg",
+                description="Latest robot image",
                 uploaded_at=image_time,
             ),
             RobotEventImageLink(
                 team_number=team_one.team_number,
                 event_key=event.event_key,
                 image_url="https://cdn.example.com/team1111-older.jpg",
+                description=None,
                 uploaded_at=image_time - timedelta(minutes=10),
             ),
             RobotEventImageLink(
                 team_number=team_two.team_number,
                 event_key=event.event_key,
                 image_url="https://cdn.example.com/team2222.jpg",
+                description="Team 2222 robot",
                 uploaded_at=image_time,
             ),
             RobotEventImageLink(
@@ -199,17 +202,25 @@ def test_event_images_endpoint_returns_grouped_links(event_images_client):
 
     expected = {
         data["team_one"]: [
-            "https://cdn.example.com/team1111-latest.jpg",
-            "https://cdn.example.com/team1111-older.jpg",
+            ("https://cdn.example.com/team1111-latest.jpg", "Latest robot image"),
+            ("https://cdn.example.com/team1111-older.jpg", None),
         ],
-        data["team_two"]: ["https://cdn.example.com/team2222.jpg"],
+        data["team_two"]: [("https://cdn.example.com/team2222.jpg", "Team 2222 robot")],
     }
 
     for entry in payload:
-        assert entry["images"] == expected[entry["teamNumber"]]
+        images = entry["images"]
+        assert [image["image_url"] for image in images] == [
+            item[0] for item in expected[entry["teamNumber"]]
+        ]
+        assert [image.get("description") for image in images] == [
+            item[1] for item in expected[entry["teamNumber"]]
+        ]
+        for image in images:
+            assert "id" in image and isinstance(image["id"], str)
 
     assert "https://cdn.example.com/team1111-other-event.jpg" not in {
-        image for entry in payload for image in entry["images"]
+        image["image_url"] for entry in payload for image in entry["images"]
     }
 
 
@@ -237,11 +248,21 @@ def test_match_images_endpoint_includes_teams_without_images(event_images_client
 
     images_by_team = {entry["teamNumber"]: entry["images"] for entry in payload}
 
-    assert images_by_team[data["team_one"]] == [
+    assert [
+        image["image_url"] for image in images_by_team[data["team_one"]]
+    ] == [
         "https://cdn.example.com/team1111-latest.jpg",
         "https://cdn.example.com/team1111-older.jpg",
     ]
-    assert images_by_team[data["team_two"]] == ["https://cdn.example.com/team2222.jpg"]
+    assert [
+        image.get("description") for image in images_by_team[data["team_one"]]
+    ] == ["Latest robot image", None]
+    assert [
+        image["image_url"] for image in images_by_team[data["team_two"]]
+    ] == ["https://cdn.example.com/team2222.jpg"]
+    assert [
+        image.get("description") for image in images_by_team[data["team_two"]]
+    ] == ["Team 2222 robot"]
     assert images_by_team[data["team_without_images"]] == []
     assert images_by_team[4444] == []
     assert images_by_team[5555] == []


### PR DESCRIPTION
## Summary
- include image identifiers and descriptions in event team image responses
- update event image aggregation logic to build structured image summaries
- refresh endpoint tests to validate the new response payload

## Testing
- pytest tests/test_event_images.py

------
https://chatgpt.com/codex/tasks/task_e_69011e19b9cc8326bfc2b27e7923d876