### PR TITLE
Add 2026 scouting alliance access regression coverage

### DIFF
--- a/tests/test_scouting_alliance_access.py
+++ b/tests/test_scouting_alliance_access.py
@@ -9,6 +9,7 @@ from app.models import (
     Endgame2025,
     FRCEvent,
     MatchData2025,
+    MatchData2026,
     MatchPredictions2025,
     MatchSchedule,
     Organization,
@@ -41,6 +42,7 @@ from tests.conftest import AsyncSessionLocal
 async def _create_alliance_context(
     event_key: str,
     season_id: int,
+    event_year: int = 2025,
     *,
     alliance_from_primary: bool = True,
     invite_status: OrgEventAllianceInviteStatus = OrgEventAllianceInviteStatus.ACCEPTED,
@@ -48,12 +50,12 @@ async def _create_alliance_context(
     async with AsyncSessionLocal() as session:
         now = datetime.utcnow()
 
-        season = Season(id=season_id, year=2025, name=f"Season {season_id}")
+        season = Season(id=season_id, year=event_year, name=f"Season {season_id}")
         event = FRCEvent(
             event_key=event_key,
             event_name="Alliance Test Event",
             short_name="Alliance",
-            year=2025,
+            year=event_year,
             week=1,
         )
         primary_org = Organization(name=f"Primary {event_key}", team_number=season_id)
@@ -552,3 +554,37 @@ async def test_removed_alliance_not_accessible(setup_database):
         )
 
     assert accessible == {context["primary_organization_id"]}
+
+
+@pytest.mark.asyncio
+async def test_match_data_includes_alliance_records_for_2026(setup_database):
+    context = await _create_alliance_context("2026alliancemd", 9301, event_year=2026)
+
+    async with AsyncSessionLocal() as session:
+        team = TeamRecord(teamNumber=2234, teamName="Alliance Team 2026")
+        session.add(team)
+        await session.commit()
+
+        match_entry = MatchData2026(
+            season=context["season_id"],
+            team_number=team.team_number,
+            event_key=context["event_key"],
+            match_number=1,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+        )
+        session.add(match_entry)
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        records = await get_match_data_for_team_at_active_event(
+            session, team.team_number, user_payload
+        )
+
+        assert len(records) == 1
+        assert records[0].organization_id == context["allied_organization_id"]


### PR DESCRIPTION
### Motivation
- Add a regression test to verify scouting alliance data visibility for 2026 so the year-aware model selection path continues to include allied organization match data when events roll over to a new season.

### Description
- Extend the `_create_alliance_context` test fixture in `tests/test_scouting_alliance_access.py` to accept an `event_year` parameter and create `Season`/`FRCEvent` for that year.
- Import `MatchData2026` and add `test_match_data_includes_alliance_records_for_2026` which inserts a `MatchData2026` record for an allied org and asserts it is returned by `get_match_data_for_team_at_active_event` for the primary org.

### Testing
- Ran `pytest -q tests/test_scouting_alliance_access.py`, which initially errored due to the environment variable `SUPABASE_JWT_SECRET` not being set.
- Re-ran `SUPABASE_JWT_SECRET=dummy pytest -q tests/test_scouting_alliance_access.py -k "2026 or includes_alliance_records"`, which reached the new test paths but the run failed because the environment lacks an async pytest plugin (e.g. `pytest-asyncio`), preventing the async tests from executing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55e2a07cc8326be95f1247a6ef741)