### PR TITLE
Queue prediction jobs for scouting alliances and handle multiple org IDs when enqueuing

### DIFF
--- a/app/routes/organizationadmin.py
+++ b/app/routes/organizationadmin.py
@@ -759,7 +759,7 @@ async def _enqueue_matches_for_prediction_queue(
     organization_id: int,
     matches: Iterable[Tuple[int, str]],
 ) -> None:
-    """Add new matches to the prediction queue for the organization.
+    """Add new matches to the prediction queue for the scouting alliance.
 
     Existing queue entries for the provided matches are left untouched to
     avoid duplicate jobs when the schedule is synchronized multiple times.
@@ -774,33 +774,45 @@ async def _enqueue_matches_for_prediction_queue(
     if not unique_matches:
         return
 
-    queue_statement = select(
-        PredictionQueue.match_number,
-        PredictionQueue.match_level,
-    ).where(
-        PredictionQueue.event_key == event_key,
-        PredictionQueue.organization_id == organization_id,
+    alliance_organization_ids = await get_scouting_alliance_organization_ids(
+        session,
+        event_key,
+        int(organization_id),
     )
-    queue_result = await session.execute(queue_statement)
-    existing_matches: Set[Tuple[int, str]] = {
-        (int(match_number), match_level)
-        for match_number, match_level in queue_result
-    }
+    if not alliance_organization_ids:
+        alliance_organization_ids = {int(organization_id)}
 
-    matches_to_queue = unique_matches - existing_matches
-    if not matches_to_queue:
-        return
-
-    queue_entries = [
-        PredictionQueue(
-            event_key=event_key,
-            match_number=match_number,
-            match_level=match_level,
-            organization_id=organization_id,
+    queue_entries: list[PredictionQueue] = []
+    for alliance_org_id in alliance_organization_ids:
+        queue_statement = select(
+            PredictionQueue.match_number,
+            PredictionQueue.match_level,
+        ).where(
+            PredictionQueue.event_key == event_key,
+            PredictionQueue.organization_id == int(alliance_org_id),
         )
-        for match_number, match_level in matches_to_queue
-    ]
-    session.add_all(queue_entries)
+        queue_result = await session.execute(queue_statement)
+        existing_matches: Set[Tuple[int, str]] = {
+            (int(match_number), match_level)
+            for match_number, match_level in queue_result
+        }
+
+        matches_to_queue = unique_matches - existing_matches
+        if not matches_to_queue:
+            continue
+
+        queue_entries.extend(
+            PredictionQueue(
+                event_key=event_key,
+                match_number=match_number,
+                match_level=match_level,
+                organization_id=int(alliance_org_id),
+            )
+            for match_number, match_level in matches_to_queue
+        )
+
+    if queue_entries:
+        session.add_all(queue_entries)
 
 
 async def _queue_matches_missing_predictions(

--- a/app/services/scout.py
+++ b/app/services/scout.py
@@ -2464,31 +2464,36 @@ async def _enqueue_unplayed_matches_for_prediction_queue(
     if not unplayed_matches:
         return
 
-    queue_statement = (
-        select(PredictionQueue.match_number, PredictionQueue.match_level)
-        .where(
-            PredictionQueue.event_key == event_key,
-            PredictionQueue.organization_id == organization_id,
+    queue_entries: List[PredictionQueue] = []
+    for accessible_org_id in accessible_org_ids:
+        queue_statement = (
+            select(PredictionQueue.match_number, PredictionQueue.match_level)
+            .where(
+                PredictionQueue.event_key == event_key,
+                PredictionQueue.organization_id == int(accessible_org_id),
+            )
         )
-    )
-    queue_result = await session.execute(queue_statement)
-    queued_matches = {
-        (row.match_number, row.match_level) for row in queue_result
-    }
+        queue_result = await session.execute(queue_statement)
+        queued_matches = {
+            (row.match_number, row.match_level) for row in queue_result
+        }
 
-    matches_to_queue = unplayed_matches - queued_matches
-    if not matches_to_queue:
+        matches_to_queue = unplayed_matches - queued_matches
+        if not matches_to_queue:
+            continue
+
+        queue_entries.extend(
+            PredictionQueue(
+                event_key=event_key,
+                match_number=match_number,
+                match_level=match_level,
+                organization_id=int(accessible_org_id),
+            )
+            for match_number, match_level in matches_to_queue
+        )
+
+    if not queue_entries:
         return
-
-    queue_entries = [
-        PredictionQueue(
-            event_key=event_key,
-            match_number=match_number,
-            match_level=match_level,
-            organization_id=organization_id,
-        )
-        for match_number, match_level in matches_to_queue
-    ]
 
     session.add_all(queue_entries)
     try:

--- a/tests/test_prediction_queue_queueing.py
+++ b/tests/test_prediction_queue_queueing.py
@@ -104,6 +104,78 @@ def test_enqueue_matches_for_prediction_queue_adds_new_matches(setup_database):
     asyncio.run(_run_test())
 
 
+def test_enqueue_matches_for_prediction_queue_adds_matches_for_alliance(setup_database):
+    async def _run_test() -> None:
+        async with AsyncSessionLocal() as session:
+            event = FRCEvent(
+                event_key="2025queuealliance",
+                event_name="Queue Alliance Event",
+                year=2025,
+                week=1,
+            )
+            org_a = Organization(name="Queue Alliance A", team_number=1717)
+            org_b = Organization(name="Queue Alliance B", team_number=2727)
+            session.add_all([event, org_a, org_b])
+            await session.commit()
+            await session.refresh(org_a)
+            await session.refresh(org_b)
+
+            org_a_event = OrganizationEvent(
+                organization_id=org_a.id,
+                event_key=event.event_key,
+                active=True,
+            )
+            org_b_event = OrganizationEvent(
+                organization_id=org_b.id,
+                event_key=event.event_key,
+                active=True,
+            )
+            session.add_all([org_a_event, org_b_event])
+            await session.commit()
+            await session.refresh(org_a_event)
+
+            session.add(
+                OrganizationEventAlliance(
+                    orgevent_Uid=org_a_event.id,
+                    other_organization_id=org_b.id,
+                    org_invite_status=OrgEventAllianceInviteStatus.ACCEPTED,
+                )
+            )
+            await session.commit()
+
+            await _enqueue_matches_for_prediction_queue(
+                session,
+                event_key=event.event_key,
+                organization_id=org_a.id,
+                matches=[(7, "qm")],
+            )
+            await session.commit()
+
+            org_a_result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == org_a.id,
+                )
+            )
+            org_b_result = await session.execute(
+                select(PredictionQueue).where(
+                    PredictionQueue.event_key == event.event_key,
+                    PredictionQueue.organization_id == org_b.id,
+                )
+            )
+
+            assert {
+                (row.match_number, row.match_level)
+                for row in org_a_result.scalars().all()
+            } == {(7, "qm")}
+            assert {
+                (row.match_number, row.match_level)
+                for row in org_b_result.scalars().all()
+            } == {(7, "qm")}
+
+    asyncio.run(_run_test())
+
+
 def test_match_sync_enqueues_missing_predictions(setup_database):
     async def _run_test() -> None:
         async with AsyncSessionLocal() as session:
@@ -189,6 +261,9 @@ def test_match_sync_enqueues_missing_predictions(setup_database):
             class _MockResponse:
                 def json(self):
                     return schedule_payload
+
+                def raise_for_status(self):
+                    return None
 
             class _MockAsyncClient:
                 def __init__(self, *args, **kwargs):
@@ -506,7 +581,11 @@ def test_editing_allied_match_queues_for_active_org(setup_database):
                     PredictionQueue.organization_id == org_a.id,
                 )
             )
-            assert not other_result.scalars().all()
+            other_queued_matches = {
+                (row.match_number, row.match_level)
+                for row in other_result.scalars().all()
+            }
+            assert other_queued_matches == {(2, "qm")}
 
     asyncio.run(_run_test())
 
@@ -608,6 +687,9 @@ def test_match_schedule_sync_queues_modified_matches(monkeypatch, setup_database
 
                 def json(self):
                     return self._payload
+
+                def raise_for_status(self):
+                    return None
 
             class MockAsyncClient:
                 def __init__(self, payload):


### PR DESCRIPTION
### Motivation

- Ensure prediction queue entries are created for all organizations in a scouting alliance when matches are enqueued, and ensure unplayed-match queuing respects multiple accessible organizations.

### Description

- Update `app/routes/organizationadmin.py::_enqueue_matches_for_prediction_queue` to fetch alliance organization IDs via `get_scouting_alliance_organization_ids`, iterate each allied org, avoid duplicates per org, cast organization IDs to `int`, and only call `session.add_all` when there are entries to add; also update the docstring to reference the scouting alliance.
- Update `app/services/scout.py::_enqueue_unplayed_matches_for_prediction_queue` to loop over `accessible_org_ids`, query existing `PredictionQueue` entries per org, build queue entries per organization, and only add and commit when entries exist.
- Add a new test `test_enqueue_matches_for_prediction_queue_adds_matches_for_alliance` and update existing tests in `tests/test_prediction_queue_queueing.py` to reflect allied enqueuing behavior and to include `raise_for_status` in mocked HTTP responses.

### Testing

- Ran the prediction-queue related tests in `tests/test_prediction_queue_queueing.py` via `pytest` and the modified tests passed.
- Ran the relevant unit tests exercising `_enqueue_matches_for_prediction_queue` and `_enqueue_unplayed_matches_for_prediction_queue` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b577c485b08326856cf1c74e749d87)