### PR TITLE
Ad-hoc TBA refresh when public match schedule is empty

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -265,7 +265,92 @@ async def get_match_schedule(
 ) -> List[MatchScheduleResponse]:
     statement = select(MatchSchedule).where(MatchSchedule.event_key == eventCode)
     result = await session.execute(statement)
-    return result.scalars().all()
+    matches = result.scalars().all()
+    if matches:
+        return matches
+
+    await _refresh_match_schedule_from_tba(session, eventCode)
+
+    refreshed_result = await session.execute(statement)
+    return refreshed_result.scalars().all()
+
+
+async def _refresh_match_schedule_from_tba(
+    session: AsyncSession, event_code: str
+) -> None:
+    if not TBA_API_KEY:
+        return
+
+    matches_url = f"{TBA_API_ENDPOINT}/event/{event_code}/matches/simple"
+    headers = {"X-TBA-Auth-Key": TBA_API_KEY, "accept": "application/json"}
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(matches_url, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPError:
+        return
+
+    payload = response.json()
+    if not isinstance(payload, list):
+        return
+
+    has_new_records = False
+    for match in payload:
+        alliances = match.get("alliances")
+        if not isinstance(alliances, dict):
+            continue
+
+        match_level = str(match.get("comp_level") or "").strip()
+        if not match_level:
+            continue
+
+        if match_level == "sf":
+            match_number_raw = match.get("set_number")
+        else:
+            match_number_raw = match.get("match_number")
+
+        try:
+            match_number = int(match_number_raw)
+        except (TypeError, ValueError):
+            continue
+
+        red_alliance = alliances.get("red")
+        blue_alliance = alliances.get("blue")
+        if not isinstance(red_alliance, dict) or not isinstance(blue_alliance, dict):
+            continue
+
+        red_team_numbers = _parse_team_numbers(red_alliance.get("team_keys") or [])
+        blue_team_numbers = _parse_team_numbers(blue_alliance.get("team_keys") or [])
+        if len(red_team_numbers) < 3 or len(blue_team_numbers) < 3:
+            continue
+
+        statement = select(MatchSchedule).where(
+            MatchSchedule.event_key == event_code,
+            MatchSchedule.match_number == match_number,
+            MatchSchedule.match_level == match_level,
+        )
+        existing = (await session.execute(statement)).scalar_one_or_none()
+        if existing is not None:
+            continue
+
+        has_new_records = True
+        session.add(
+            MatchSchedule(
+                event_key=event_code,
+                match_number=match_number,
+                match_level=match_level,
+                red1_id=red_team_numbers[0],
+                red2_id=red_team_numbers[1],
+                red3_id=red_team_numbers[2],
+                blue1_id=blue_team_numbers[0],
+                blue2_id=blue_team_numbers[1],
+                blue3_id=blue_team_numbers[2],
+            )
+        )
+
+    if has_new_records:
+        await session.commit()
 
 
 async def get_match_schedule_or_404(session: AsyncSession, eventCode: str) -> List[MatchScheduleResponse]:

--- a/tests/test_public_events_endpoint.py
+++ b/tests/test_public_events_endpoint.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -7,6 +8,7 @@ os.environ.setdefault("SUPABASE_JWT_SECRET", "test-secret")
 
 from app.main import app
 from app.models import FRCEvent
+from app.services import event as event_service
 from tests.conftest import AsyncSessionLocal
 
 
@@ -57,10 +59,10 @@ def test_list_events_uses_event_name_when_short_name_missing(setup_database):
 
 
 
-async def _prepare_event_without_schedule() -> FRCEvent:
+async def _prepare_event_without_schedule(event_key: str = "2024noschedule") -> FRCEvent:
     async with AsyncSessionLocal() as session:
         event = FRCEvent(
-            event_key="2024noschedule",
+            event_key=event_key,
             event_name="No Schedule Event",
             short_name="NoSchedule",
             year=2024,
@@ -80,3 +82,63 @@ def test_public_match_schedule_returns_empty_list_when_no_matches(setup_database
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_public_match_schedule_fetches_adhoc_when_db_empty(monkeypatch, setup_database):
+    event = asyncio.run(_prepare_event_without_schedule("2024noscheduleadhoc"))
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> list[dict[str, Any]]:
+            return [
+                {
+                    "comp_level": "qm",
+                    "match_number": 1,
+                    "alliances": {
+                        "red": {"team_keys": ["frc111", "frc222", "frc333"]},
+                        "blue": {"team_keys": ["frc444", "frc555", "frc666"]},
+                    },
+                }
+            ]
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url: str, headers: dict[str, str]):
+            assert url.endswith(f"/event/{event.event_key}/matches/simple")
+            assert "X-TBA-Auth-Key" in headers
+            return _FakeResponse()
+
+    monkeypatch.setattr(event_service, "TBA_API_KEY", "test-api-key")
+    monkeypatch.setattr(event_service.httpx, "AsyncClient", _FakeAsyncClient)
+
+    with TestClient(app) as client:
+        response = client.get(f"/public/matchSchedule/{event.event_key}")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "event_key": event.event_key,
+            "match_number": 1,
+            "match_level": "qm",
+            "red1_id": 111,
+            "red2_id": 222,
+            "red3_id": 333,
+            "blue1_id": 444,
+            "blue2_id": 555,
+            "blue3_id": 666,
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Ensure the public `/public/matchSchedule/{eventCode}` endpoint can return a schedule even when the local `MatchSchedule` table is empty by doing a one-time ad-hoc pull from The Blue Alliance.
- Keep the endpoint resilient so it still returns existing local data (including an empty list) if the TBA API key is not configured, the request fails, or the payload is invalid.

### Description
- Updated `get_match_schedule` to re-query after attempting an ad-hoc refresh when no local matches exist by calling the new helper ` _refresh_match_schedule_from_tba` in `app/services/event.py`.
- Added `async def _refresh_match_schedule_from_tba(session, event_code)` which safely fetches `GET /event/{event}/matches/simple` from TBA, validates payload structure, parses alliances via the existing `_parse_team_numbers` helper, and inserts only non-duplicate, valid `MatchSchedule` rows, committing only when new records are added.
- Made the helper no-op if `TBA_API_KEY` is missing or if the HTTP request/payload parsing fails so behavior is non-breaking.
- Added test coverage in `tests/test_public_events_endpoint.py` to assert both the unchanged empty-list fallback and the new ad-hoc fetch-and-persist behavior.

### Testing
- Ran `pytest -q tests/test_public_events_endpoint.py`, which completed successfully with all tests passing (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5673279188326adaa1ce9dc895249)