### PR TITLE
Include scouting alliance data in match previews

### DIFF
--- a/app/services/event.py
+++ b/app/services/event.py
@@ -984,12 +984,15 @@ async def _fetch_team_records(
     session: AsyncSession,
     match_model: type[SQLModel],
     event_key: str,
-    organization_id: int,
+    organization_ids: Sequence[int],
     team_number: int,
 ) -> List[SQLModel]:
+    if not organization_ids:
+        return []
+
     statement = select(match_model).where(
         match_model.event_key == event_key,
-        match_model.organization_id == organization_id,
+        match_model.organization_id.in_(tuple(int(org_id) for org_id in organization_ids)),
         match_model.team_number == team_number,
     )
     result = await session.execute(statement)
@@ -1000,7 +1003,7 @@ async def _build_alliance_preview(
     session: AsyncSession,
     match_model: type[SQLModel],
     event_key: str,
-    organization_id: int,
+    organization_ids: Sequence[int],
     team_numbers: Sequence[int],
     auto_weights: Dict[str, float],
     teleop_weights: Dict[str, float],
@@ -1015,7 +1018,7 @@ async def _build_alliance_preview(
             session,
             match_model,
             event_key,
-            organization_id,
+            organization_ids,
             int(team_number),
         )
         team_preview, counts_average = _build_team_preview_from_records(
@@ -1063,6 +1066,13 @@ async def get_match_preview(
     endgame_points = resolve_endgame_points_mapping(match_model, MATCH_MODEL_ENDGAME_POINTS_ATTR, DEFAULT_ENDGAME_POINTS)
 
     include_levels = season.id != 2
+    alliance_organization_ids = tuple(
+        sorted(
+            await get_scouting_alliance_organization_ids(
+                session, event_key, membership.organization_id
+            )
+        )
+    )
 
     red_teams = [match.red1_id, match.red2_id, match.red3_id]
     blue_teams = [match.blue1_id, match.blue2_id, match.blue3_id]
@@ -1071,7 +1081,7 @@ async def get_match_preview(
         session,
         match_model,
         event_key,
-        membership.organization_id,
+        alliance_organization_ids,
         red_teams,
         auto_weights,
         teleop_weights,
@@ -1083,7 +1093,7 @@ async def get_match_preview(
         session,
         match_model,
         event_key,
-        membership.organization_id,
+        alliance_organization_ids,
         blue_teams,
         auto_weights,
         teleop_weights,

--- a/tests/test_scouting_alliance_access.py
+++ b/tests/test_scouting_alliance_access.py
@@ -24,7 +24,7 @@ from app.models import (
     UserRole,
     ValidationStatus,
 )
-from app.services.event import get_scouting_alliance_organization_ids
+from app.services.event import get_match_preview, get_scouting_alliance_organization_ids
 from app.services.match_prediction import get_match_prediction_for_user_organization
 from app.services.scout import (
     DataValidationFilterRequest,
@@ -235,6 +235,53 @@ async def test_superscout_access_includes_allied_data(setup_database):
         alliance_info = alliances[0]["alliances"]
         assert alliance_info["red"] is True
         assert alliance_info["blue"] is False
+
+
+@pytest.mark.asyncio
+async def test_match_preview_includes_allied_compiled_averages(setup_database):
+    context = await _create_alliance_context("2025alliancepreview", 9302)
+
+    async with AsyncSessionLocal() as session:
+        teams = [
+            TeamRecord(teamNumber=number, teamName=f"Team {number}")
+            for number in range(6101, 6107)
+        ]
+        session.add_all(teams)
+        await session.commit()
+
+        schedule = MatchSchedule(
+            event_key=context["event_key"],
+            match_number=3,
+            match_level="qm",
+            red1_id=6101,
+            red2_id=6102,
+            red3_id=6103,
+            blue1_id=6104,
+            blue2_id=6105,
+            blue3_id=6106,
+        )
+
+        allied_record = MatchData2025(
+            season=context["season_id"],
+            team_number=6101,
+            event_key=context["event_key"],
+            match_number=1,
+            match_level="qm",
+            user_id=context["allied_user_id"],
+            organization_id=context["allied_organization_id"],
+            autoL4=2,
+        )
+        session.add_all([schedule, allied_record])
+        await session.commit()
+
+        user_payload = {
+            "id": str(context["primary_user_id"]),
+            "user_org": context["primary_membership_id"],
+        }
+
+        preview = await get_match_preview(session, user_payload, 3, "qm")
+        red_team_preview = next(team for team in preview.red.teams if team.team_number == 6101)
+        assert red_team_preview.auto.level4.average == pytest.approx(2.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Match previews were only pulling match records for the active organization, so compiled averages in previews omitted allied organizations’ scouting data when alliances were in effect.
- The change ensures users in a scouting alliance see compiled averages that include accepted allied organizations’ match records.

### Description
- Update `_fetch_team_records` to accept `organization_ids: Sequence[int]`, return early on an empty list, and query with `organization_id.in_(...)` instead of a single org equality. 
- Thread `organization_ids` through `_build_alliance_preview` and call sites so per-team record fetches include all accessible alliance org IDs. 
- In `get_match_preview` resolve `alliance_organization_ids` via `get_scouting_alliance_organization_ids(session, event_key, membership.organization_id)` and pass the tuple to the alliance preview builder. 
- Add `test_match_preview_includes_allied_compiled_averages` to `tests/test_scouting_alliance_access.py` and adjust imports to exercise the new behavior.

### Testing
- Ran `python -m compileall app/services/event.py tests/test_scouting_alliance_access.py`, which completed successfully. 
- Ran `pytest` for the new test but the environment initially failed due to a missing `SUPABASE_JWT_SECRET` variable; re-ran with `SUPABASE_JWT_SECRET=test` and the test run failed because the test environment lacks an async pytest plugin (e.g. `pytest-asyncio`), so async tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5252a7a9083269df4ef9ccc975153)